### PR TITLE
Add rollout telemetry and metrics logging

### DIFF
--- a/schemas/metrics.py
+++ b/schemas/metrics.py
@@ -12,3 +12,8 @@ class EpisodeMetrics:
     final_treasury: float | None = None
     final_productivity: float | None = None
     termination_reason: str | None = None
+    invalid_action_count: int = 0
+    parse_error_count: int = 0
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    total_tokens: int = 0

--- a/schemas/metrics.py
+++ b/schemas/metrics.py
@@ -17,3 +17,11 @@ class EpisodeMetrics:
     prompt_tokens: int = 0
     completion_tokens: int = 0
     total_tokens: int = 0
+    critical_failure_count: int = 0
+    bankruptcy_count: int = 0
+    shutdown_count: int = 0
+    average_revenue_factor: float | None = None
+    treasury_stability: float | None = None
+    productivity_growth: float | None = None
+    debate_message_count: int = 0
+    proposals_passed_count: int = 0

--- a/telemetry/__init__.py
+++ b/telemetry/__init__.py
@@ -1,5 +1,14 @@
 """Central telemetry for rollouts, evaluation, and training datasets."""
 
 from telemetry.episode_logger import EpisodeLogger
+from telemetry.events import TelemetryEvent, TelemetryEventType
+from telemetry.metrics_collector import MetricsCollector
+from telemetry.run_summary import RunSummary
 
-__all__ = ["EpisodeLogger"]
+__all__ = [
+    "EpisodeLogger",
+    "MetricsCollector",
+    "RunSummary",
+    "TelemetryEvent",
+    "TelemetryEventType",
+]

--- a/telemetry/episode_logger.py
+++ b/telemetry/episode_logger.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import Any
+from warnings import warn
 
 from telemetry.events import TelemetryEvent, TelemetryEventType, normalize_event_type, serialize_value
 from telemetry.jsonl_writer import JsonlWriter
@@ -29,10 +30,25 @@ class EpisodeLogger:
         **payload_fields: Any,
     ) -> TelemetryEvent:
         if "round" in payload_fields and round_number is None:
+            warn(
+                "Use round_number=... instead of payload field round=....",
+                DeprecationWarning,
+                stacklevel=2,
+            )
             round_number = payload_fields.pop("round")
         if "phase" in payload_fields and phase is None:
+            warn(
+                "Use phase=... as a top-level logger argument.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
             phase = payload_fields.pop("phase")
         if "agent_id" in payload_fields and agent_id is None:
+            warn(
+                "Use agent_id=... as a top-level logger argument.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
             agent_id = payload_fields.pop("agent_id")
 
         serialized_payload = serialize_value(payload or {})
@@ -115,6 +131,38 @@ class EpisodeLogger:
             payload=payload,
         )
 
+    def log_proposal(
+        self,
+        proposal: Any,
+        *,
+        round_number: int | None = None,
+        phase: str | int | None = None,
+        agent_id: str | None = None,
+    ) -> TelemetryEvent:
+        return self.log(
+            TelemetryEventType.PROPOSAL,
+            round_number=round_number,
+            phase=phase,
+            agent_id=agent_id,
+            proposal=proposal,
+        )
+
+    def log_vote(
+        self,
+        vote: Any,
+        *,
+        round_number: int | None = None,
+        phase: str | int | None = None,
+        agent_id: str | None = None,
+    ) -> TelemetryEvent:
+        return self.log(
+            TelemetryEventType.VOTE,
+            round_number=round_number,
+            phase=phase,
+            agent_id=agent_id,
+            vote=vote,
+        )
+
     def log_reward(
         self,
         reward: Any,
@@ -129,6 +177,48 @@ class EpisodeLogger:
             phase=phase,
             agent_id=agent_id,
             reward=reward,
+        )
+
+    def log_treasury(
+        self,
+        treasury: float,
+        *,
+        round_number: int | None = None,
+        phase: str | int | None = None,
+    ) -> TelemetryEvent:
+        return self.log(
+            TelemetryEventType.TREASURY,
+            round_number=round_number,
+            phase=phase,
+            treasury=treasury,
+        )
+
+    def log_prosperity(
+        self,
+        prosperity: float,
+        *,
+        round_number: int | None = None,
+        phase: str | int | None = None,
+    ) -> TelemetryEvent:
+        return self.log(
+            TelemetryEventType.PROSPERITY,
+            round_number=round_number,
+            phase=phase,
+            prosperity=prosperity,
+        )
+
+    def log_productivity(
+        self,
+        productivity: float,
+        *,
+        round_number: int | None = None,
+        phase: str | int | None = None,
+    ) -> TelemetryEvent:
+        return self.log(
+            TelemetryEventType.PRODUCTIVITY,
+            round_number=round_number,
+            phase=phase,
+            productivity=productivity,
         )
 
     def log_termination(
@@ -162,22 +252,21 @@ class EpisodeLogger:
         agent_id: str | None = None,
         model: str | None = None,
     ) -> TelemetryEvent:
-        payload = {
-            key: value
-            for key, value in {
-                "prompt": prompt,
-                "completion": completion,
-                "prompt_tokens": prompt_tokens,
-                "completion_tokens": completion_tokens,
-                "total_tokens": total_tokens,
-                "model": model,
-            }.items()
-            if value is not None
-        }
         return self.log(
             TelemetryEventType.LLM_CALL,
             round_number=round_number,
             phase=phase,
             agent_id=agent_id,
-            payload=payload,
+            payload=_without_none(
+                prompt=prompt,
+                completion=completion,
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+                total_tokens=total_tokens,
+                model=model,
+            ),
         )
+
+
+def _without_none(**values: Any) -> dict[str, Any]:
+    return {key: value for key, value in values.items() if value is not None}

--- a/telemetry/episode_logger.py
+++ b/telemetry/episode_logger.py
@@ -2,10 +2,9 @@
 
 from __future__ import annotations
 
-from dataclasses import asdict, is_dataclass
 from typing import Any
 
-from telemetry.events import TelemetryEvent
+from telemetry.events import TelemetryEvent, TelemetryEventType, normalize_event_type, serialize_value
 from telemetry.jsonl_writer import JsonlWriter
 
 
@@ -19,25 +18,166 @@ class EpisodeLogger:
         self.writer = writer
         self.events: list[TelemetryEvent] = []
 
-    def log(self, event_type: str, **payload: Any) -> TelemetryEvent:
+    def log(
+        self,
+        event_type: TelemetryEventType | str,
+        *,
+        round_number: int | None = None,
+        phase: str | int | None = None,
+        agent_id: str | None = None,
+        payload: dict[str, Any] | None = None,
+        **payload_fields: Any,
+    ) -> TelemetryEvent:
+        if "round" in payload_fields and round_number is None:
+            round_number = payload_fields.pop("round")
+        if "phase" in payload_fields and phase is None:
+            phase = payload_fields.pop("phase")
+        if "agent_id" in payload_fields and agent_id is None:
+            agent_id = payload_fields.pop("agent_id")
+
+        serialized_payload = serialize_value(payload or {})
+        serialized_payload.update(
+            {key: serialize_value(value) for key, value in payload_fields.items()}
+        )
+
         event = TelemetryEvent(
-            event_type=event_type,
+            event_type=normalize_event_type(event_type),
             episode_id=self.episode_id,
-            payload={key: _serialize(value) for key, value in payload.items()},
+            round=round_number,
+            phase=serialize_value(phase),
+            agent_id=agent_id,
+            payload=serialized_payload,
         )
         self.events.append(event)
         if self.writer is not None:
             self.writer.write(event.to_dict())
         return event
 
+    def log_observation(
+        self,
+        observation: Any,
+        *,
+        round_number: int | None = None,
+        phase: str | int | None = None,
+        agent_id: str | None = None,
+    ) -> TelemetryEvent:
+        return self.log(
+            TelemetryEventType.OBSERVATION,
+            round_number=round_number,
+            phase=phase,
+            agent_id=agent_id,
+            observation=observation,
+        )
 
-def _serialize(value: Any) -> Any:
-    if is_dataclass(value):
-        return asdict(value)
-    if isinstance(value, tuple):
-        return [_serialize(item) for item in value]
-    if isinstance(value, list):
-        return [_serialize(item) for item in value]
-    if isinstance(value, dict):
-        return {key: _serialize(item) for key, item in value.items()}
-    return value
+    def log_action_selected(
+        self,
+        action: Any,
+        *,
+        round_number: int | None = None,
+        phase: str | int | None = None,
+        agent_id: str | None = None,
+        valid_actions: Any | None = None,
+        raw_response: str | None = None,
+    ) -> TelemetryEvent:
+        payload = {"action": action}
+        if valid_actions is not None:
+            payload["valid_actions"] = valid_actions
+        if raw_response is not None:
+            payload["raw_response"] = raw_response
+        return self.log(
+            TelemetryEventType.ACTION_SELECTED,
+            round_number=round_number,
+            phase=phase,
+            agent_id=agent_id,
+            payload=payload,
+        )
+
+    def log_action_validated(
+        self,
+        *,
+        is_valid: bool,
+        round_number: int | None = None,
+        phase: str | int | None = None,
+        agent_id: str | None = None,
+        reason: str | None = None,
+        action: Any | None = None,
+    ) -> TelemetryEvent:
+        payload: dict[str, Any] = {"is_valid": is_valid}
+        if reason is not None:
+            payload["reason"] = reason
+        if action is not None:
+            payload["action"] = action
+        return self.log(
+            TelemetryEventType.ACTION_VALIDATED,
+            round_number=round_number,
+            phase=phase,
+            agent_id=agent_id,
+            payload=payload,
+        )
+
+    def log_reward(
+        self,
+        reward: Any,
+        *,
+        round_number: int | None = None,
+        phase: str | int | None = None,
+        agent_id: str | None = None,
+    ) -> TelemetryEvent:
+        return self.log(
+            TelemetryEventType.REWARD,
+            round_number=round_number,
+            phase=phase,
+            agent_id=agent_id,
+            reward=reward,
+        )
+
+    def log_termination(
+        self,
+        termination_reason: str,
+        *,
+        round_number: int | None = None,
+        phase: str | int | None = None,
+        final_state: Any | None = None,
+    ) -> TelemetryEvent:
+        payload: dict[str, Any] = {"termination_reason": termination_reason}
+        if final_state is not None:
+            payload["final_state"] = final_state
+        return self.log(
+            TelemetryEventType.TERMINATION,
+            round_number=round_number,
+            phase=phase,
+            payload=payload,
+        )
+
+    def log_llm_call(
+        self,
+        *,
+        prompt: str | None = None,
+        completion: str | None = None,
+        prompt_tokens: int | None = None,
+        completion_tokens: int | None = None,
+        total_tokens: int | None = None,
+        round_number: int | None = None,
+        phase: str | int | None = None,
+        agent_id: str | None = None,
+        model: str | None = None,
+    ) -> TelemetryEvent:
+        payload = {
+            key: value
+            for key, value in {
+                "prompt": prompt,
+                "completion": completion,
+                "prompt_tokens": prompt_tokens,
+                "completion_tokens": completion_tokens,
+                "total_tokens": total_tokens,
+                "model": model,
+            }.items()
+            if value is not None
+        }
+        return self.log(
+            TelemetryEventType.LLM_CALL,
+            round_number=round_number,
+            phase=phase,
+            agent_id=agent_id,
+            payload=payload,
+        )

--- a/telemetry/events.py
+++ b/telemetry/events.py
@@ -1,18 +1,56 @@
-"""Structured telemetry events."""
+"""Structured telemetry events emitted during rollouts."""
 
-from dataclasses import asdict, dataclass, field
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field, is_dataclass
 from datetime import UTC, datetime
+from enum import Enum, StrEnum
 from typing import Any
 from uuid import uuid4
+
+
+class TelemetryEventType(StrEnum):
+    OBSERVATION = "observation"
+    ACTION_SELECTED = "action_selected"
+    ACTION_VALIDATED = "action_validated"
+    REWARD = "reward"
+    TERMINATION = "termination"
+    LLM_CALL = "llm_call"
+    RUN_SUMMARY = "run_summary"
 
 
 @dataclass(frozen=True, slots=True)
 class TelemetryEvent:
     event_type: str
     episode_id: str
-    payload: dict[str, Any]
+    payload: dict[str, Any] = field(default_factory=dict)
+    round: int | None = None
+    phase: str | int | None = None
+    agent_id: str | None = None
     event_id: str = field(default_factory=lambda: str(uuid4()))
     timestamp: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
 
     def to_dict(self) -> dict[str, Any]:
-        return asdict(self)
+        return serialize_value(asdict(self))
+
+
+def normalize_event_type(event_type: TelemetryEventType | str) -> str:
+    if isinstance(event_type, TelemetryEventType):
+        return event_type.value
+    return str(event_type)
+
+
+def serialize_value(value: Any) -> Any:
+    if hasattr(value, "to_dict") and callable(value.to_dict):
+        return serialize_value(value.to_dict())
+    if is_dataclass(value) and not isinstance(value, type):
+        return serialize_value(asdict(value))
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, tuple):
+        return [serialize_value(item) for item in value]
+    if isinstance(value, list):
+        return [serialize_value(item) for item in value]
+    if isinstance(value, dict):
+        return {str(key): serialize_value(item) for key, item in value.items()}
+    return value

--- a/telemetry/events.py
+++ b/telemetry/events.py
@@ -2,21 +2,32 @@
 
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass, field, is_dataclass
+from dataclasses import dataclass, field, fields, is_dataclass
 from datetime import UTC, datetime
 from enum import Enum, StrEnum
 from typing import Any
 from uuid import uuid4
+
+MAX_SERIALIZATION_DEPTH = 32
 
 
 class TelemetryEventType(StrEnum):
     OBSERVATION = "observation"
     ACTION_SELECTED = "action_selected"
     ACTION_VALIDATED = "action_validated"
+    PROPOSAL = "proposal"
+    VOTE = "vote"
     REWARD = "reward"
+    TREASURY = "treasury"
+    PROSPERITY = "prosperity"
+    PRODUCTIVITY = "productivity"
     TERMINATION = "termination"
     LLM_CALL = "llm_call"
     RUN_SUMMARY = "run_summary"
+
+
+class TelemetrySerializationError(ValueError):
+    """Raised when a telemetry payload cannot be safely serialized."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -31,7 +42,16 @@ class TelemetryEvent:
     timestamp: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
 
     def to_dict(self) -> dict[str, Any]:
-        return serialize_value(asdict(self))
+        return {
+            "event_id": self.event_id,
+            "episode_id": self.episode_id,
+            "timestamp": self.timestamp,
+            "event_type": self.event_type,
+            "round": self.round,
+            "phase": serialize_value(self.phase),
+            "agent_id": self.agent_id,
+            "payload": serialize_value(self.payload),
+        }
 
 
 def normalize_event_type(event_type: TelemetryEventType | str) -> str:
@@ -40,17 +60,96 @@ def normalize_event_type(event_type: TelemetryEventType | str) -> str:
     return str(event_type)
 
 
-def serialize_value(value: Any) -> Any:
-    if hasattr(value, "to_dict") and callable(value.to_dict):
-        return serialize_value(value.to_dict())
-    if is_dataclass(value) and not isinstance(value, type):
-        return serialize_value(asdict(value))
+def serialize_value(
+    value: Any,
+    *,
+    max_depth: int = MAX_SERIALIZATION_DEPTH,
+    _seen: set[int] | None = None,
+    _depth: int = 0,
+) -> Any:
+    if _depth > max_depth:
+        raise TelemetrySerializationError("Telemetry payload exceeds maximum depth.")
+
     if isinstance(value, Enum):
         return value.value
-    if isinstance(value, tuple):
-        return [serialize_value(item) for item in value]
-    if isinstance(value, list):
-        return [serialize_value(item) for item in value]
+    if value is None or isinstance(value, str | int | float | bool):
+        return value
+
+    seen = _seen if _seen is not None else set()
+    value_id = id(value)
+    if value_id in seen:
+        raise TelemetrySerializationError("Telemetry payload contains a circular reference.")
+
+    if hasattr(value, "to_dict") and callable(value.to_dict):
+        seen.add(value_id)
+        try:
+            return serialize_value(
+                value.to_dict(),
+                max_depth=max_depth,
+                _seen=seen,
+                _depth=_depth + 1,
+            )
+        finally:
+            seen.remove(value_id)
+
+    if is_dataclass(value) and not isinstance(value, type):
+        seen.add(value_id)
+        try:
+            return {
+                field.name: serialize_value(
+                    getattr(value, field.name),
+                    max_depth=max_depth,
+                    _seen=seen,
+                    _depth=_depth + 1,
+                )
+                for field in fields(value)
+            }
+        finally:
+            seen.remove(value_id)
+
     if isinstance(value, dict):
-        return {str(key): serialize_value(item) for key, item in value.items()}
+        seen.add(value_id)
+        try:
+            return {
+                str(key): serialize_value(
+                    item,
+                    max_depth=max_depth,
+                    _seen=seen,
+                    _depth=_depth + 1,
+                )
+                for key, item in value.items()
+            }
+        finally:
+            seen.remove(value_id)
+
+    if isinstance(value, tuple | list):
+        seen.add(value_id)
+        try:
+            return [
+                serialize_value(
+                    item,
+                    max_depth=max_depth,
+                    _seen=seen,
+                    _depth=_depth + 1,
+                )
+                for item in value
+            ]
+        finally:
+            seen.remove(value_id)
+
+    if isinstance(value, set | frozenset):
+        seen.add(value_id)
+        try:
+            return [
+                serialize_value(
+                    item,
+                    max_depth=max_depth,
+                    _seen=seen,
+                    _depth=_depth + 1,
+                )
+                for item in sorted(value, key=repr)
+            ]
+        finally:
+            seen.remove(value_id)
+
     return value

--- a/telemetry/metrics_collector.py
+++ b/telemetry/metrics_collector.py
@@ -1,13 +1,97 @@
-"""Small metric accumulator for seeded evaluation runs."""
+"""Metric accumulator for seeded evaluation and rollout runs."""
+
+from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Any
+
+from schemas.metrics import EpisodeMetrics
 
 
 @dataclass(slots=True)
 class MetricsCollector:
     total_reward: float = 0.0
     rounds_survived: int = 0
+    final_treasury: float | None = None
+    final_prosperity: float | None = None
+    final_productivity: float | None = None
+    termination_reason: str | None = None
+    invalid_action_count: int = 0
+    parse_error_count: int = 0
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    total_tokens: int = 0
 
     def record_step(self, reward: float, round_number: int) -> None:
+        self.record_reward(reward, round_number=round_number)
+
+    def record_reward(self, reward: float, *, round_number: int | None = None) -> None:
         self.total_reward += reward
+        if round_number is not None:
+            self.rounds_survived = max(self.rounds_survived, round_number)
+
+    def record_round(self, round_number: int) -> None:
         self.rounds_survived = max(self.rounds_survived, round_number)
+
+    def record_action_validation(
+        self,
+        *,
+        is_valid: bool,
+        parse_error: bool = False,
+    ) -> None:
+        if not is_valid:
+            self.invalid_action_count += 1
+        if parse_error:
+            self.parse_error_count += 1
+
+    def record_invalid_action(self, *, parse_error: bool = False) -> None:
+        self.record_action_validation(is_valid=False, parse_error=parse_error)
+
+    def record_llm_tokens(
+        self,
+        *,
+        prompt_tokens: int | None = None,
+        completion_tokens: int | None = None,
+        total_tokens: int | None = None,
+    ) -> None:
+        prompt_count = prompt_tokens or 0
+        completion_count = completion_tokens or 0
+        self.prompt_tokens += prompt_count
+        self.completion_tokens += completion_count
+        self.total_tokens += total_tokens if total_tokens is not None else (
+            prompt_count + completion_count
+        )
+
+    def record_final_state(
+        self,
+        *,
+        final_treasury: float | None = None,
+        final_prosperity: float | None = None,
+        final_productivity: float | None = None,
+        termination_reason: str | None = None,
+        rounds_survived: int | None = None,
+    ) -> None:
+        self.final_treasury = final_treasury
+        self.final_prosperity = final_prosperity
+        self.final_productivity = final_productivity
+        self.termination_reason = termination_reason
+        if rounds_survived is not None:
+            self.rounds_survived = max(self.rounds_survived, rounds_survived)
+
+    def build_summary(self, episode_id: str, **overrides: Any) -> EpisodeMetrics:
+        values = {
+            "episode_id": episode_id,
+            "rounds_survived": self.rounds_survived,
+            "total_reward": self.total_reward,
+            "final_prosperity": self.final_prosperity,
+            "final_treasury": self.final_treasury,
+            "final_productivity": self.final_productivity,
+            "termination_reason": self.termination_reason,
+            "invalid_action_count": self.invalid_action_count,
+            "parse_error_count": self.parse_error_count,
+            "prompt_tokens": self.prompt_tokens,
+            "completion_tokens": self.completion_tokens,
+            "total_tokens": self.total_tokens,
+        }
+        values.update(overrides)
+        return EpisodeMetrics(**values)

--- a/telemetry/metrics_collector.py
+++ b/telemetry/metrics_collector.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from statistics import pvariance
 from typing import Any
 
 from schemas.metrics import EpisodeMetrics
@@ -21,6 +22,15 @@ class MetricsCollector:
     prompt_tokens: int = 0
     completion_tokens: int = 0
     total_tokens: int = 0
+    critical_failure_count: int = 0
+    bankruptcy_count: int = 0
+    shutdown_count: int = 0
+    debate_message_count: int = 0
+    proposals_passed_count: int = 0
+    _revenue_factors: list[float] = field(default_factory=list, repr=False)
+    _treasury_values: list[float] = field(default_factory=list, repr=False)
+    _initial_productivity: float | None = field(default=None, repr=False)
+    _termination_counted: bool = field(default=False, repr=False)
 
     def record_step(self, reward: float, round_number: int) -> None:
         self.record_reward(reward, round_number=round_number)
@@ -58,9 +68,42 @@ class MetricsCollector:
         completion_count = completion_tokens or 0
         self.prompt_tokens += prompt_count
         self.completion_tokens += completion_count
-        self.total_tokens += total_tokens if total_tokens is not None else (
-            prompt_count + completion_count
-        )
+        if total_tokens is not None:
+            self.total_tokens += total_tokens
+            return
+        self.total_tokens += prompt_count + completion_count
+
+    def record_revenue_factor(self, revenue_factor: float) -> None:
+        self._revenue_factors.append(revenue_factor)
+
+    def record_treasury(self, treasury: float) -> None:
+        self.final_treasury = treasury
+        self._treasury_values.append(treasury)
+
+    def record_productivity(self, productivity: float) -> None:
+        if self._initial_productivity is None:
+            self._initial_productivity = productivity
+        self.final_productivity = productivity
+
+    def record_debate_message(self, count: int = 1) -> None:
+        self.debate_message_count += count
+
+    def record_proposal_passed(self, count: int = 1) -> None:
+        self.proposals_passed_count += count
+
+    def record_termination(self, termination_reason: str) -> None:
+        self.termination_reason = termination_reason
+        if self._termination_counted:
+            return
+
+        normalized_reason = termination_reason.lower()
+        if "critical" in normalized_reason:
+            self.critical_failure_count += 1
+        elif "bankrupt" in normalized_reason:
+            self.bankruptcy_count += 1
+        elif "shutdown" in normalized_reason or "governance collapse" in normalized_reason:
+            self.shutdown_count += 1
+        self._termination_counted = True
 
     def record_final_state(
         self,
@@ -71,14 +114,24 @@ class MetricsCollector:
         termination_reason: str | None = None,
         rounds_survived: int | None = None,
     ) -> None:
-        self.final_treasury = final_treasury
+        if final_treasury is not None:
+            if self._treasury_values and self._treasury_values[-1] == final_treasury:
+                self.final_treasury = final_treasury
+            else:
+                self.record_treasury(final_treasury)
         self.final_prosperity = final_prosperity
-        self.final_productivity = final_productivity
-        self.termination_reason = termination_reason
+        if final_productivity is not None:
+            self.final_productivity = final_productivity
+        if termination_reason is not None:
+            self.record_termination(termination_reason)
         if rounds_survived is not None:
             self.rounds_survived = max(self.rounds_survived, rounds_survived)
 
     def build_summary(self, episode_id: str, **overrides: Any) -> EpisodeMetrics:
+        productivity_growth = None
+        if self._initial_productivity is not None and self.final_productivity is not None:
+            productivity_growth = self.final_productivity - self._initial_productivity
+
         values = {
             "episode_id": episode_id,
             "rounds_survived": self.rounds_survived,
@@ -92,6 +145,28 @@ class MetricsCollector:
             "prompt_tokens": self.prompt_tokens,
             "completion_tokens": self.completion_tokens,
             "total_tokens": self.total_tokens,
+            "critical_failure_count": self.critical_failure_count,
+            "bankruptcy_count": self.bankruptcy_count,
+            "shutdown_count": self.shutdown_count,
+            "average_revenue_factor": _mean(self._revenue_factors),
+            "treasury_stability": _variance(self._treasury_values),
+            "productivity_growth": productivity_growth,
+            "debate_message_count": self.debate_message_count,
+            "proposals_passed_count": self.proposals_passed_count,
         }
         values.update(overrides)
         return EpisodeMetrics(**values)
+
+
+def _mean(values: list[float]) -> float | None:
+    if not values:
+        return None
+    return sum(values) / len(values)
+
+
+def _variance(values: list[float]) -> float | None:
+    if not values:
+        return None
+    if len(values) == 1:
+        return 0.0
+    return pvariance(values)

--- a/telemetry/run_summary.py
+++ b/telemetry/run_summary.py
@@ -30,3 +30,77 @@ class RunSummary:
             sum(episode.rounds_survived for episode in self.episodes)
             / self.episode_count
         )
+
+    @property
+    def critical_failure_rate(self) -> float:
+        return self._rate("critical_failure_count")
+
+    @property
+    def bankruptcy_rate(self) -> float:
+        return self._rate("bankruptcy_count")
+
+    @property
+    def shutdown_rate(self) -> float:
+        return self._rate("shutdown_count")
+
+    @property
+    def mean_final_prosperity(self) -> float | None:
+        return self._mean_optional("final_prosperity")
+
+    @property
+    def mean_average_revenue_factor(self) -> float | None:
+        return self._mean_optional("average_revenue_factor")
+
+    @property
+    def mean_treasury_stability(self) -> float | None:
+        return self._mean_optional("treasury_stability")
+
+    @property
+    def mean_productivity_growth(self) -> float | None:
+        return self._mean_optional("productivity_growth")
+
+    @property
+    def invalid_action_count(self) -> int:
+        return self._sum("invalid_action_count")
+
+    @property
+    def parse_error_count(self) -> int:
+        return self._sum("parse_error_count")
+
+    @property
+    def prompt_tokens(self) -> int:
+        return self._sum("prompt_tokens")
+
+    @property
+    def completion_tokens(self) -> int:
+        return self._sum("completion_tokens")
+
+    @property
+    def total_tokens(self) -> int:
+        return self._sum("total_tokens")
+
+    @property
+    def debate_message_count(self) -> int:
+        return self._sum("debate_message_count")
+
+    @property
+    def proposals_passed_count(self) -> int:
+        return self._sum("proposals_passed_count")
+
+    def _rate(self, field_name: str) -> float:
+        if not self.episodes:
+            return 0.0
+        return self._sum(field_name) / self.episode_count
+
+    def _sum(self, field_name: str) -> int:
+        return sum(getattr(episode, field_name) for episode in self.episodes)
+
+    def _mean_optional(self, field_name: str) -> float | None:
+        values = [
+            value
+            for episode in self.episodes
+            if (value := getattr(episode, field_name)) is not None
+        ]
+        if not values:
+            return None
+        return sum(values) / len(values)

--- a/telemetry/run_summary.py
+++ b/telemetry/run_summary.py
@@ -1,0 +1,32 @@
+"""Helpers for serializing completed rollout summaries."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from schemas.metrics import EpisodeMetrics
+
+
+@dataclass(frozen=True, slots=True)
+class RunSummary:
+    run_id: str
+    episodes: tuple[EpisodeMetrics, ...] = field(default_factory=tuple)
+
+    @property
+    def episode_count(self) -> int:
+        return len(self.episodes)
+
+    @property
+    def mean_total_reward(self) -> float:
+        if not self.episodes:
+            return 0.0
+        return sum(episode.total_reward for episode in self.episodes) / self.episode_count
+
+    @property
+    def mean_rounds_survived(self) -> float:
+        if not self.episodes:
+            return 0.0
+        return (
+            sum(episode.rounds_survived for episode in self.episodes)
+            / self.episode_count
+        )

--- a/tests/unit/test_episode_logger.py
+++ b/tests/unit/test_episode_logger.py
@@ -1,16 +1,26 @@
 import json
 
 from schemas.actions import ActionType, DebateAction
+from schemas.phases import Phase
+from schemas.rewards import RewardInfo
 from telemetry import EpisodeLogger
 from telemetry.jsonl_writer import JsonlWriter
 
 
 def test_episode_logger_keeps_events_in_memory() -> None:
     logger = EpisodeLogger(episode_id="episode-1")
-    event = logger.log("action_selected", agent_id="Health", action="DEBATE")
+    event = logger.log_action_selected(
+        DebateAction(type=ActionType.DEBATE, message="Fund Health."),
+        round_number=2,
+        phase=Phase.DEBATE,
+        agent_id="Health",
+    )
 
     assert event.episode_id == "episode-1"
-    assert event.payload["agent_id"] == "Health"
+    assert event.event_type == "action_selected"
+    assert event.round == 2
+    assert event.phase == 2
+    assert event.agent_id == "Health"
     assert logger.events == [event]
 
 
@@ -21,12 +31,78 @@ def test_episode_logger_writes_jsonl(tmp_path) -> None:
         writer=JsonlWriter(output_path),
     )
 
-    logger.log(
-        "action_selected",
-        action=DebateAction(type=ActionType.DEBATE, message="Fund Health."),
+    logger.log_action_selected(
+        DebateAction(type=ActionType.DEBATE, message="Fund Health."),
+        round_number=1,
+        phase=Phase.DEBATE,
+        agent_id="Health",
     )
 
     line = output_path.read_text(encoding="utf-8").strip()
     record = json.loads(line)
+    assert set(record) == {
+        "agent_id",
+        "episode_id",
+        "event_id",
+        "event_type",
+        "payload",
+        "phase",
+        "round",
+        "timestamp",
+    }
+    assert record["episode_id"] == "episode-1"
     assert record["event_type"] == "action_selected"
+    assert record["round"] == 1
+    assert record["phase"] == 2
+    assert record["agent_id"] == "Health"
     assert record["payload"]["action"]["message"] == "Fund Health."
+
+
+def test_dataclass_payloads_serialize_correctly(tmp_path) -> None:
+    output_path = tmp_path / "episode.jsonl"
+    logger = EpisodeLogger(
+        episode_id="episode-1",
+        writer=JsonlWriter(output_path),
+    )
+
+    logger.log_reward(
+        RewardInfo(total=4.5, survival_bonus=1.0),
+        round_number=3,
+        agent_id="Commerce",
+    )
+
+    record = json.loads(output_path.read_text(encoding="utf-8"))
+    assert record["event_type"] == "reward"
+    assert record["payload"]["reward"] == {
+        "allocation_penalty": 0.0,
+        "base_reward": 0.0,
+        "critical_penalty": 0.0,
+        "productivity_bonus": 0.0,
+        "survival_bonus": 1.0,
+        "total": 4.5,
+    }
+
+
+def test_jsonl_output_is_append_only(tmp_path) -> None:
+    output_path = tmp_path / "episode.jsonl"
+    first_logger = EpisodeLogger(
+        episode_id="episode-1",
+        writer=JsonlWriter(output_path),
+    )
+    second_logger = EpisodeLogger(
+        episode_id="episode-2",
+        writer=JsonlWriter(output_path),
+    )
+
+    first_logger.log_observation({"treasury": 1000}, round_number=1)
+    second_logger.log_termination("max_rounds", round_number=50)
+
+    records = [
+        json.loads(line)
+        for line in output_path.read_text(encoding="utf-8").splitlines()
+    ]
+    assert [record["episode_id"] for record in records] == ["episode-1", "episode-2"]
+    assert [record["event_type"] for record in records] == [
+        "observation",
+        "termination",
+    ]

--- a/tests/unit/test_episode_logger.py
+++ b/tests/unit/test_episode_logger.py
@@ -1,9 +1,13 @@
 import json
+from dataclasses import dataclass
+
+import pytest
 
 from schemas.actions import ActionType, DebateAction
 from schemas.phases import Phase
 from schemas.rewards import RewardInfo
 from telemetry import EpisodeLogger
+from telemetry.events import TelemetrySerializationError
 from telemetry.jsonl_writer import JsonlWriter
 
 
@@ -106,3 +110,53 @@ def test_jsonl_output_is_append_only(tmp_path) -> None:
         "observation",
         "termination",
     ]
+
+
+def test_logger_rejects_circular_payloads(tmp_path) -> None:
+    @dataclass
+    class Node:
+        name: str
+        child: "Node | None" = None
+
+    output_path = tmp_path / "episode.jsonl"
+    logger = EpisodeLogger(
+        episode_id="episode-1",
+        writer=JsonlWriter(output_path),
+    )
+    parent = Node(name="parent")
+    child = Node(name="child", child=parent)
+    parent.child = child
+
+    with pytest.raises(TelemetrySerializationError):
+        logger.log_observation(parent, round_number=1)
+
+
+def test_spec_required_helpers_emit_consistent_payloads(tmp_path) -> None:
+    output_path = tmp_path / "episode.jsonl"
+    logger = EpisodeLogger(
+        episode_id="episode-1",
+        writer=JsonlWriter(output_path),
+    )
+
+    logger.log_proposal({"proposal_id": "p1"}, round_number=2, agent_id="Health")
+    logger.log_vote({"proposal_id": "p1", "vote": "YES"}, round_number=2)
+    logger.log_treasury(950.0, round_number=2)
+    logger.log_prosperity(1200.0, round_number=2)
+    logger.log_productivity(1.1, round_number=2)
+
+    records = [
+        json.loads(line)
+        for line in output_path.read_text(encoding="utf-8").splitlines()
+    ]
+    assert [record["event_type"] for record in records] == [
+        "proposal",
+        "vote",
+        "treasury",
+        "prosperity",
+        "productivity",
+    ]
+    assert records[0]["payload"] == {"proposal": {"proposal_id": "p1"}}
+    assert records[1]["payload"] == {"vote": {"proposal_id": "p1", "vote": "YES"}}
+    assert records[2]["payload"] == {"treasury": 950.0}
+    assert records[3]["payload"] == {"prosperity": 1200.0}
+    assert records[4]["payload"] == {"productivity": 1.1}

--- a/tests/unit/test_metrics_collector.py
+++ b/tests/unit/test_metrics_collector.py
@@ -1,4 +1,8 @@
+import pytest
+
+from schemas.metrics import EpisodeMetrics
 from telemetry.metrics_collector import MetricsCollector
+from telemetry.run_summary import RunSummary
 
 
 def test_metrics_collector_accumulates_rewards() -> None:
@@ -28,11 +32,18 @@ def test_metrics_collector_builds_final_summary() -> None:
     collector.record_reward(10.0, round_number=3)
     collector.record_llm_tokens(prompt_tokens=12, completion_tokens=8)
     collector.record_llm_tokens(total_tokens=5)
+    collector.record_revenue_factor(1.2)
+    collector.record_revenue_factor(1.6)
+    collector.record_treasury(1000.0)
+    collector.record_treasury(1200.0)
+    collector.record_productivity(1.0)
+    collector.record_debate_message()
+    collector.record_proposal_passed()
     collector.record_final_state(
         final_treasury=1200.0,
         final_prosperity=1600.0,
         final_productivity=1.2,
-        termination_reason="max_rounds",
+        termination_reason="critical_failure",
         rounds_survived=5,
     )
 
@@ -44,7 +55,87 @@ def test_metrics_collector_builds_final_summary() -> None:
     assert summary.final_treasury == 1200.0
     assert summary.final_prosperity == 1600.0
     assert summary.final_productivity == 1.2
-    assert summary.termination_reason == "max_rounds"
+    assert summary.termination_reason == "critical_failure"
     assert summary.prompt_tokens == 12
     assert summary.completion_tokens == 8
     assert summary.total_tokens == 25
+    assert summary.critical_failure_count == 1
+    assert summary.bankruptcy_count == 0
+    assert summary.shutdown_count == 0
+    assert summary.average_revenue_factor == pytest.approx(1.4)
+    assert summary.treasury_stability == 10000.0
+    assert summary.productivity_growth == pytest.approx(0.2)
+    assert summary.debate_message_count == 1
+    assert summary.proposals_passed_count == 1
+
+
+def test_metrics_collector_uses_explicit_total_tokens() -> None:
+    collector = MetricsCollector()
+
+    collector.record_llm_tokens(
+        prompt_tokens=10,
+        completion_tokens=5,
+        total_tokens=20,
+    )
+
+    assert collector.prompt_tokens == 10
+    assert collector.completion_tokens == 5
+    assert collector.total_tokens == 20
+
+
+def test_run_summary_aggregates_evaluation_metrics() -> None:
+    summary = RunSummary(
+        run_id="run-1",
+        episodes=(
+            EpisodeMetrics(
+                episode_id="episode-1",
+                rounds_survived=5,
+                total_reward=10.0,
+                final_prosperity=1000.0,
+                critical_failure_count=1,
+                average_revenue_factor=1.2,
+                treasury_stability=25.0,
+                productivity_growth=0.1,
+                invalid_action_count=2,
+                prompt_tokens=10,
+                completion_tokens=5,
+                total_tokens=15,
+                debate_message_count=3,
+                proposals_passed_count=1,
+            ),
+            EpisodeMetrics(
+                episode_id="episode-2",
+                rounds_survived=7,
+                total_reward=14.0,
+                final_prosperity=1400.0,
+                shutdown_count=1,
+                average_revenue_factor=1.4,
+                treasury_stability=75.0,
+                productivity_growth=0.3,
+                parse_error_count=1,
+                prompt_tokens=20,
+                completion_tokens=10,
+                total_tokens=30,
+                debate_message_count=5,
+                proposals_passed_count=2,
+            ),
+        ),
+    )
+
+    assert summary.episode_count == 2
+    assert summary.mean_total_reward == 12.0
+    assert summary.mean_rounds_survived == 6.0
+    assert summary.critical_failure_rate == 0.5
+    assert summary.bankruptcy_rate == 0.0
+    assert summary.shutdown_rate == 0.5
+    assert summary.mean_final_prosperity == 1200.0
+    assert summary.mean_average_revenue_factor == pytest.approx(1.3)
+    assert summary.mean_treasury_stability == 50.0
+    assert summary.mean_productivity_growth == pytest.approx(0.2)
+    assert summary.invalid_action_count == 2
+    assert summary.parse_error_count == 1
+    assert summary.prompt_tokens == 30
+    assert summary.completion_tokens == 15
+    assert summary.total_tokens == 45
+    assert summary.debate_message_count == 8
+    assert summary.proposals_passed_count == 3

--- a/tests/unit/test_metrics_collector.py
+++ b/tests/unit/test_metrics_collector.py
@@ -1,0 +1,50 @@
+from telemetry.metrics_collector import MetricsCollector
+
+
+def test_metrics_collector_accumulates_rewards() -> None:
+    collector = MetricsCollector()
+
+    collector.record_reward(2.5, round_number=1)
+    collector.record_step(3.0, round_number=4)
+    collector.record_reward(-1.0)
+
+    assert collector.total_reward == 4.5
+    assert collector.rounds_survived == 4
+
+
+def test_metrics_collector_records_invalid_actions() -> None:
+    collector = MetricsCollector()
+
+    collector.record_action_validation(is_valid=True)
+    collector.record_action_validation(is_valid=False)
+    collector.record_invalid_action(parse_error=True)
+
+    assert collector.invalid_action_count == 2
+    assert collector.parse_error_count == 1
+
+
+def test_metrics_collector_builds_final_summary() -> None:
+    collector = MetricsCollector()
+    collector.record_reward(10.0, round_number=3)
+    collector.record_llm_tokens(prompt_tokens=12, completion_tokens=8)
+    collector.record_llm_tokens(total_tokens=5)
+    collector.record_final_state(
+        final_treasury=1200.0,
+        final_prosperity=1600.0,
+        final_productivity=1.2,
+        termination_reason="max_rounds",
+        rounds_survived=5,
+    )
+
+    summary = collector.build_summary("episode-1")
+
+    assert summary.episode_id == "episode-1"
+    assert summary.total_reward == 10.0
+    assert summary.rounds_survived == 5
+    assert summary.final_treasury == 1200.0
+    assert summary.final_prosperity == 1600.0
+    assert summary.final_productivity == 1.2
+    assert summary.termination_reason == "max_rounds"
+    assert summary.prompt_tokens == 12
+    assert summary.completion_tokens == 8
+    assert summary.total_tokens == 25


### PR DESCRIPTION
## Summary
- Standardize rollout telemetry events around stable JSONL fields: `event_id`, `episode_id`, `timestamp`, `event_type`, `round`, `phase`, `agent_id`, and `payload`.
- Add typed episode logger helpers for observations, selected actions, validation results, rewards, termination, and LLM calls.
- Expand metrics collection and episode summaries with reward totals, survival rounds, final state values, termination reason, invalid/parse-error counts, and token usage.

## Details
This PR turns telemetry into a reusable source of truth for later plots, evaluation comparisons, qualitative playback, and training-data conversion. The generic `EpisodeLogger.log(...)` API remains available, while the new typed helpers make rollout call sites less error-prone and keep common event payloads consistent.

`TelemetryEvent` now serializes schema dataclasses, enums, tuples, lists, and dictionaries into JSON-safe values before writing records. JSONL writing remains append-only through the existing writer.

`MetricsCollector` now accumulates the episode-level metrics required by the RL adapter and evaluation specs, including LLM-specific token counts when present. A small `RunSummary` helper is included for aggregating completed episode metrics across a rollout run.

This intentionally does not depend on `core/game.py` being complete; callers can emit telemetry from adapters, evaluators, or future environment wiring without requiring a finished episode runner.

## Tests
- `/opt/homebrew/bin/uv sync --extra dev`
- `/opt/homebrew/bin/uv run pytest tests/unit/test_episode_logger.py`
- `/opt/homebrew/bin/uv run pytest tests/unit/test_metrics_collector.py`
- `/opt/homebrew/bin/uv run pytest`

Full suite result: `68 passed`.

## Notes
- Left unrelated local working-tree files out of this PR: `.sisyphus/notepads/F2/learnings.md`, `.cursor/`, and `uv.lock`.