### PR TITLE
Implement NationGame orchestration

### DIFF
--- a/core/game.py
+++ b/core/game.py
@@ -352,6 +352,10 @@ class NationGame:
         agent_id = str(action.get("agent_id") or action.get("agent") or department)
         amount = action.get("amount")
 
+        if department in self._submitted_departments:
+            info["ignored_actions"].append({"action": dict(action), "reason": "duplicate_proposal"})
+            return
+
         rejection_reason = self._proposal_rejection_reason(agent_id, department, amount)
         if rejection_reason is not None:
             proposal = self._new_proposal(
@@ -481,7 +485,16 @@ class NationGame:
                     self.sectors[proposal.department].allocation + proposal.amount
                 )
 
-        critical_failed = any(sector.is_critical_failure(self.population.value) for sector in self.sectors.values())
+        approved_departments = {
+            proposal.department
+            for proposal in self.proposals
+            if proposal.status == PROPOSAL_STATUS_APPROVED
+        }
+        critical_failed = any(
+            sector.is_critical_failure(self.population.value)
+            for sector in self.sectors.values()
+            if sector.name in approved_departments
+        )
         if critical_failed:
             self.last_total_allocation = sum(sector.allocation for sector in self.sectors.values())
             return True
@@ -489,7 +502,7 @@ class NationGame:
         self.last_total_allocation = 0.0
         for sector in self.sectors.values():
             self.last_total_allocation += sector.allocation
-            self.treasury.balance -= sector.allocation
+            self.treasury.debit(sector.allocation)
         return False
 
     def _tally_votes(self) -> None:
@@ -529,6 +542,8 @@ class NationGame:
     ) -> None:
         completed_round = completed_round or self.round
         if critical_failed:
+            self.last_total_revenue = 0.0
+            self.last_total_surplus = 0.0
             self.done = True
             self.termination_reason = TERMINATION_CRITICAL_FAILURE
         else:
@@ -622,8 +637,6 @@ class NationGame:
             return "unknown_department"
         if agent_id != department:
             return "wrong_department"
-        if department in self._submitted_departments:
-            return "duplicate_proposal"
         if amount_value < 0 or math.isnan(amount_value) or math.isinf(amount_value):
             return "invalid_amount"
         if amount_value > self.treasury.balance:

--- a/core/game.py
+++ b/core/game.py
@@ -1,485 +1,697 @@
-"""
-game.py — Main game orchestrator.
-
-NationGame is the pure-Python game engine.  It has zero framework
-dependencies and communicates entirely via plain dicts / dataclasses.
-
-Input:  allocations dict  {"Social": 90, "Defense": 150, …}
-Output: StepResult with treasury, revenues, reward, done, etc.
-
-The server/ layer (OpenEnv wrapper) sits on top of this.
-"""
+"""NationGame orchestration for the phased core game loop."""
 
 from __future__ import annotations
 
+import math
 import random
 from dataclasses import dataclass, field
-from typing import Any
+from enum import StrEnum
+from typing import Any, Iterable, Mapping
+
+from schemas.actions import ActionType, VoteChoice
+from schemas.phases import Phase, valid_action_types_for_phase
 
 from .config import DEFAULT_CONFIG, GameConfig
 from .events import Event, EventEngine
 from .population import PopulationTracker
 from .productivity import ProductivityTracker
-from .reward import RewardResult, compute_reward
+from .reward import RewardBreakdown, compute_reward
 from .sector import Sector
 from .treasury import Treasury
 
 
-# ── Step result ─────────────────────────────────────────────────
+PHASE_COUNT = 9
+PROPOSAL_STATUS_PENDING = "pending"
+PROPOSAL_STATUS_APPROVED = "approved"
+PROPOSAL_STATUS_REJECTED = "rejected"
+PROPOSAL_STATUS_REJECTED_INVALID = "rejected_invalid"
+TERMINATION_CRITICAL_FAILURE = "CRITICAL_FAILURE"
+TERMINATION_BANKRUPTCY = "BANKRUPTCY"
+TERMINATION_SHUTDOWN = "SHUTDOWN"
+TERMINATION_MAX_ROUNDS = "MAX_ROUNDS"
+TERMINATION_PROSPERITY = "PROSPERITY_THRESHOLD"
+
+
+@dataclass
+class Proposal:
+    """Public budget proposal submitted during phase 3."""
+
+    proposal_id: str
+    agent_id: str
+    department: str
+    amount: float
+    justification: str = ""
+    status: str = PROPOSAL_STATUS_PENDING
+    votes: dict[str, str] = field(default_factory=dict)
+    rejection_reason: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "proposal_id": self.proposal_id,
+            "agent_id": self.agent_id,
+            "department": self.department,
+            "amount": self.amount,
+            "justification": self.justification,
+            "status": self.status,
+            "votes": dict(self.votes),
+            "rejection_reason": self.rejection_reason,
+        }
+
 
 @dataclass
 class StepResult:
-    """Everything the environment needs after one round."""
+    """Result returned by :meth:`NationGame.step`."""
 
-    # Round info
-    round_num: int
-    year: int
-    quarter: int
-
-    # Treasury
-    treasury: float
-
-    # Per-sector data
-    allocations: dict[str, float]
-    revenue_factors: dict[str, float]
-    revenues: dict[str, float]
-    consumptions: dict[str, float]
-    demands: dict[str, float]
-
-    # Aggregates
-    total_revenue: float
-    total_allocation: float
-    surplus_returned: float
-
-    # Persistent state
-    population: int
-    productivity: float
-
-    # Reward
-    reward: RewardResult
-
-    # Events
-    events: list[Event]
-    crisis_occurred: bool
-
-    # Termination
+    observation: dict[str, Any]
+    reward: RewardBreakdown
     done: bool
-    termination_reason: str | None  # CRITICAL_FAILURE | BANKRUPTCY | SHUTDOWN | MAX_ROUNDS | PROSPERITY_ACHIEVED
+    info: dict[str, Any] = field(default_factory=dict)
 
-    def to_dict(self) -> dict:
-        """Serialise for agent observation / logging."""
+    @property
+    def round_num(self) -> int:
+        return self.observation["round"]
+
+    @property
+    def termination_reason(self) -> str | None:
+        return self.info.get("termination_reason")
+
+    @property
+    def treasury(self) -> float:
+        return self.observation["treasury"]
+
+    @property
+    def productivity(self) -> float:
+        return self.observation["productivity"]
+
+    @property
+    def population(self) -> int:
+        return self.observation["population"]
+
+    @property
+    def year(self) -> int:
+        return self.observation["year"]
+
+    @property
+    def quarter(self) -> int:
+        return self.observation["quarter"]
+
+    @property
+    def allocations(self) -> dict[str, float]:
         return {
+            name: sector["allocation"]
+            for name, sector in self.observation["sectors"].items()
+        }
+
+    @property
+    def revenue_factors(self) -> dict[str, float]:
+        return {
+            name: sector["revenue_factor"]
+            for name, sector in self.observation["sectors"].items()
+        }
+
+    @property
+    def revenues(self) -> dict[str, float]:
+        return {
+            name: sector["revenue"]
+            for name, sector in self.observation["sectors"].items()
+        }
+
+    @property
+    def consumptions(self) -> dict[str, float]:
+        return {
+            name: sector["consumption"]
+            for name, sector in self.observation["sectors"].items()
+        }
+
+    @property
+    def demands(self) -> dict[str, float]:
+        return {
+            name: sector["demand"]
+            for name, sector in self.observation["sectors"].items()
+        }
+
+    @property
+    def total_revenue(self) -> float:
+        return self.observation["last_total_revenue"]
+
+    @property
+    def total_allocation(self) -> float:
+        return self.observation["last_total_allocation"]
+
+    @property
+    def surplus_returned(self) -> float:
+        return self.observation["last_total_surplus"]
+
+    @property
+    def events(self) -> list[dict[str, Any]]:
+        return self.observation["current_events"]
+
+    @property
+    def crisis_occurred(self) -> bool:
+        return bool(self.info.get("crisis_occurred", False))
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise the result for legacy callers and environment wrappers."""
+        return {
+            **self.observation,
             "round_num": self.round_num,
-            "year": self.year,
-            "quarter": self.quarter,
-            "treasury": round(self.treasury, 4),
-            "allocations": {k: round(v, 4) for k, v in self.allocations.items()},
-            "revenue_factors": {k: round(v, 6) for k, v in self.revenue_factors.items()},
-            "revenues": {k: round(v, 4) for k, v in self.revenues.items()},
-            "consumptions": {k: round(v, 4) for k, v in self.consumptions.items()},
-            "demands": {k: round(v, 4) for k, v in self.demands.items()},
-            "total_revenue": round(self.total_revenue, 4),
-            "total_allocation": round(self.total_allocation, 4),
-            "surplus_returned": round(self.surplus_returned, 4),
-            "population": self.population,
-            "productivity": round(self.productivity, 6),
+            "allocations": self.allocations,
+            "revenue_factors": self.revenue_factors,
+            "revenues": self.revenues,
+            "consumptions": self.consumptions,
+            "demands": self.demands,
+            "total_revenue": self.total_revenue,
+            "total_allocation": self.total_allocation,
+            "surplus_returned": self.surplus_returned,
             "reward": self.reward.to_dict(),
-            "events": [e.to_dict() for e in self.events],
-            "crisis_occurred": self.crisis_occurred,
             "done": self.done,
             "termination_reason": self.termination_reason,
         }
 
 
-# ── Main game class ────────────────────────────────────────────
-
 class NationGame:
-    """
-    Pure-Python game engine for the Nation Simulator.
+    """Playable core game loop across the nine specified phases."""
 
-    Usage::
-
-        game = NationGame(seed=42)
-        obs = game.reset()
-
-        while not obs["done"]:
-            allocations = my_agent.decide(obs)
-            result = game.step(allocations)
-            obs = result.to_dict()
-    """
-
-    def __init__(
-        self,
-        config: GameConfig | None = None,
-        seed: int | None = None,
-    ):
+    def __init__(self, config: GameConfig | None = None, seed: int | None = None) -> None:
         self.config = config or DEFAULT_CONFIG
+        self._initial_seed = seed
         self.rng = random.Random(seed)
+        self.event_engine = EventEngine(rng=self.rng)
+        self.reset(seed=seed)
 
-        # These are initialised in reset()
-        self._sectors: dict[str, Sector] = {}
-        self._treasury: Treasury | None = None
-        self._productivity: ProductivityTracker | None = None
-        self._population: PopulationTracker | None = None
-        self._event_engine: EventEngine | None = None
+    def reset(self, seed: int | None = None) -> dict[str, Any]:
+        """Start a new episode and reveal round 1 events."""
+        if seed is not None:
+            self._initial_seed = seed
+            self.rng = random.Random(seed)
+            self.event_engine = EventEngine(rng=self.rng)
 
-        self._round: int = 0
-        self._done: bool = True
-        self._termination_reason: str | None = None
-        self._shutdown_counter: int = 0
-        self._prosperity_streak: int = 0
-        self._event_ledger: list[Event] = []
+        self.round = 1
+        self.phase = Phase.EVENT_REVELATION
+        self.done = False
+        self.termination_reason: str | None = None
+        self.total_reward = 0.0
+        self.last_reward = compute_reward(prosperity=0.0)
+        self.last_info: dict[str, Any] = {}
+        self.shutdown_counter = 0
+        self.prosperity_streak = 0
+        self.last_total_revenue = 0.0
+        self.last_total_surplus = 0.0
+        self.last_total_allocation = 0.0
+        self.current_round_crisis = False
+        self.current_events: list[Event] = []
+        self.event_ledger: list[dict[str, Any]] = []
+        self.debate_messages: list[dict[str, str]] = []
+        self.proposals: list[Proposal] = []
+        self.votes: list[dict[str, str]] = []
+        self._proposal_counter = 0
+        self._submitted_departments: set[str] = set()
+        self._abstained_departments: set[str] = set()
 
-    # ── Reset ───────────────────────────────────────────────────
-
-    def reset(self) -> dict:
-        """
-        Reset the game to the initial state.
-
-        Returns
-        -------
-        dict
-            Initial observation (treasury, sectors, population, etc.).
-        """
-        cfg = self.config
-
-        # Sectors
-        self._sectors = {}
-        for name in cfg.SECTOR_ORDER:
-            meta = cfg.SECTOR_META.get(name, {})
-            info = {"baseline": cfg.SECTOR_BASELINES[name], **meta}
-            self._sectors[name] = Sector.from_config(name, info, cfg)
-
-        # Treasury
-        self._treasury = Treasury(
-            balance=cfg.INITIAL_TREASURY,
-            baseline_tax=cfg.BASELINE_TAX,
+        self.treasury = Treasury(
+            balance=self.config.INITIAL_TREASURY,
+            baseline_tax=self.config.BASELINE_TAX,
         )
-
-        # Trackers
-        self._productivity = ProductivityTracker(
-            value=cfg.INITIAL_PRODUCTIVITY,
-            min_val=cfg.PRODUCTIVITY_MIN,
-            max_val=cfg.PRODUCTIVITY_MAX,
-            step=cfg.PRODUCTIVITY_STEP,
+        self.population = PopulationTracker(
+            value=self.config.POP_0,
+            birth_rate_base=self.config.BIRTH_RATE_BASE,
+            death_rate_base=self.config.DEATH_RATE_BASE,
+            crisis_death_penalty=self.config.CRISIS_DEATH_PENALTY,
         )
-        self._population = PopulationTracker(
-            value=cfg.POP_0,
-            birth_rate_base=cfg.BIRTH_RATE_BASE,
-            death_rate_base=cfg.DEATH_RATE_BASE,
-            crisis_death_penalty=cfg.CRISIS_DEATH_PENALTY,
+        self.productivity = ProductivityTracker(
+            value=self.config.INITIAL_PRODUCTIVITY,
+            min_val=self.config.PRODUCTIVITY_MIN,
+            max_val=self.config.PRODUCTIVITY_MAX,
+            step=self.config.PRODUCTIVITY_STEP,
         )
-
-        # Event engine
-        self._event_engine = EventEngine(rng=self.rng)
-
-        # Episode state
-        self._round = 0
-        self._done = False
-        self._termination_reason = None
-        self._shutdown_counter = 0
-        self._prosperity_streak = 0
-        self._event_ledger = []
-
-        return self._build_observation(events=[], crisis=False)
-
-    # ── Step ────────────────────────────────────────────────────
-
-    def step(self, allocations: dict[str, float]) -> StepResult:
-        """
-        Execute one complete round (Phases 1-9).
-
-        Parameters
-        ----------
-        allocations : dict[str, float]
-            Budget allocation per sector, e.g. ``{"Social": 90, "Defense": 150}``.
-            Missing sectors receive 0.  Values must be ≥ 0.
-
-        Returns
-        -------
-        StepResult
-            Full round data including reward, termination, etc.
-        """
-        if self._done:
-            raise RuntimeError("Game is over. Call reset() to start a new episode.")
-
-        cfg = self.config
-        self._round += 1
-
-        # ── Phase 1: Event revelation ───────────────────────────
-        for s in self._sectors.values():
-            s.reset_round()
-
-        events = self._event_engine.generate_events(
-            sector_names=list(self._sectors.keys()),
-        )
-
-        # ── Apply event multipliers to sectors + treasury inject
-        crisis = self._event_engine.apply_events(
-            events, self._sectors, self._treasury,
-        )
-        self._event_ledger.extend(events)
-
-        # ── Update thresholds (with population + event mults) ──
-        for s in self._sectors.values():
-            s.update_thresholds(
-                population=self._population.value,
-                pop_0=cfg.POP_0,
+        self.sectors = {
+            name: Sector(
+                name=name,
+                baseline=baseline,
+                full_name=self.config.SECTOR_META.get(name, {}).get("full_name", name),
+                description=self.config.SECTOR_META.get(name, {}).get("description", ""),
+                _critical_ratio=self.config.CRITICAL_RATIO,
+                _surplus_ratio=self.config.SURPLUS_RATIO,
+                _wastage_ratio=self.config.WASTAGE_RATIO,
+                _rf_max=self.config.RF_MAX,
             )
-
-        # ── Normalise allocations dict ──────────────────────────
-        alloc = {
-            name: max(0.0, float(allocations.get(name, 0.0)))
-            for name in self._sectors
+            for name, baseline in self.config.SECTOR_BASELINES.items()
         }
-        total_allocation = sum(alloc.values())
 
-        # ── Phase 5a: Critical threshold check ──────────────────
-        critical_failed = False
-        for name, sector in self._sectors.items():
-            sector.allocation = alloc[name]
-            if alloc[name] < sector.critical:
-                critical_failed = True
+        self._start_round()
+        return self.state()
 
-        if critical_failed:
-            return self._terminate(
-                alloc, events, crisis,
-                reason="CRITICAL_FAILURE",
-                critical_failed=True,
-            )
-
-        # ── Phase 5b: Debit treasury ────────────────────────────
-        self._treasury.debit(total_allocation)
-
-        # ── Phase 6: Consumption ────────────────────────────────
-        total_surplus = 0.0
-        for s in self._sectors.values():
-            total_surplus += s.compute_consumption()
-
-        # ── Phase 7: Revenue calculation ────────────────────────
-        total_revenue = 0.0
-        for name, sector in self._sectors.items():
-            rev = sector.compute_revenue(
-                allocation=alloc[name],
-                productivity=self._productivity.value,
-            )
-            # rev should never be None here (critical check passed)
-            total_revenue += rev or 0.0
-
-        # Credit revenue to treasury
-        self._treasury.credit(total_revenue)
-
-        # ── Phase 8: Surplus return ─────────────────────────────
-        self._treasury.credit(total_surplus)
-
-        # ── Baseline tax ────────────────────────────────────────
-        self._treasury.apply_baseline_tax()
-
-        # ── Phase 9: State updates & termination ────────────────
-
-        # Productivity update
-        rf_values = [s.revenue_factor_value for s in self._sectors.values()]
-        avg_rf = sum(rf_values) / len(rf_values) if rf_values else 1.0
-        self._productivity.update(avg_rf)
-
-        # Population update
-        self._population.update(self._productivity.value, crisis)
-
-        # Shutdown counter
-        if total_allocation == 0:
-            self._shutdown_counter += 1
-        else:
-            self._shutdown_counter = 0
-
-        # Treasury snapshot
-        self._treasury.snapshot()
-
-        # ── Check termination conditions ────────────────────────
-        done = False
-        reason = None
-
-        if self._shutdown_counter >= cfg.SHUTDOWN_THRESHOLD:
-            done, reason = True, "SHUTDOWN"
-        elif self._treasury.is_bankrupt():
-            done, reason = True, "BANKRUPTCY"
-        elif self._round >= cfg.MAX_ROUNDS:
-            done, reason = True, "MAX_ROUNDS"
-        elif cfg.PROSPERITY_THRESHOLD is not None:
-            prosperity = total_revenue / max(self._population.value, 1)
-            if prosperity >= cfg.PROSPERITY_THRESHOLD:
-                self._prosperity_streak += 1
-                if self._prosperity_streak >= cfg.PROSPERITY_STREAK:
-                    done, reason = True, "PROSPERITY_ACHIEVED"
-            else:
-                self._prosperity_streak = 0
-
-        self._done = done
-        self._termination_reason = reason
-
-        # ── Compute reward ──────────────────────────────────────
-        reward = compute_reward(
-            sectors=self._sectors,
-            total_revenue=total_revenue,
-            population=self._population.value,
-            productivity=self._productivity.value,
-            round_num=self._round,
-            critical_failed=False,
-            productivity_bonus_scale=cfg.PRODUCTIVITY_BONUS_SCALE,
-            survival_bonus_per_round=cfg.SURVIVAL_BONUS_PER_ROUND,
-            over_alloc_penalty_val=cfg.OVER_ALLOC_PENALTY,
-            under_alloc_penalty_val=cfg.UNDER_ALLOC_PENALTY,
-            critical_penalty_val=cfg.CRITICAL_PENALTY,
-        )
-
-        # Add bankruptcy penalty on top if applicable
-        if reason == "BANKRUPTCY":
-            reward = RewardResult(
-                base_reward=reward.base_reward,
-                productivity_bonus=reward.productivity_bonus,
-                survival_bonus=reward.survival_bonus,
-                over_alloc_penalty=reward.over_alloc_penalty,
-                under_alloc_penalty=reward.under_alloc_penalty,
-                critical_penalty=cfg.BANKRUPTCY_PENALTY,
-            )
-
-        year, quarter = self._time_display()
-
-        return StepResult(
-            round_num=self._round,
-            year=year,
-            quarter=quarter,
-            treasury=self._treasury.balance,
-            allocations={n: s.allocation for n, s in self._sectors.items()},
-            revenue_factors={n: s.revenue_factor_value for n, s in self._sectors.items()},
-            revenues={n: s.revenue for n, s in self._sectors.items()},
-            consumptions={n: s.consumption for n, s in self._sectors.items()},
-            demands={n: s.demand for n, s in self._sectors.items()},
-            total_revenue=total_revenue,
-            total_allocation=total_allocation,
-            surplus_returned=total_surplus,
-            population=self._population.value,
-            productivity=self._productivity.value,
-            reward=reward,
-            events=events,
-            crisis_occurred=crisis,
-            done=done,
-            termination_reason=reason,
-        )
-
-    # ── Properties ──────────────────────────────────────────────
-
-    @property
-    def current_round(self) -> int:
-        return self._round
-
-    @property
-    def is_done(self) -> bool:
-        return self._done
-
-    @property
-    def sector_names(self) -> list[str]:
-        return list(self._sectors.keys())
-
-    @property
-    def event_ledger(self) -> list[Event]:
-        return list(self._event_ledger)
-
-    @property
-    def state(self) -> dict:
-        """Full game state for serialisation / checkpointing."""
+    def state(self) -> dict[str, Any]:
+        """Return a structured public state snapshot."""
+        year, quarter = self._year_quarter(self.round)
         return {
-            "round": self._round,
-            "done": self._done,
-            "termination_reason": self._termination_reason,
-            "treasury": self._treasury.balance if self._treasury else 0,
-            "population": self._population.value if self._population else 0,
-            "productivity": self._productivity.value if self._productivity else 0,
-            "sectors": {
-                n: s.to_dict() for n, s in self._sectors.items()
+            "round": self.round,
+            "phase": self.phase,
+            "phase_name": self.phase.name,
+            "year": year,
+            "quarter": quarter,
+            "treasury": round(self.treasury.balance, 6),
+            "population": self.population.value,
+            "productivity": round(self.productivity.value, 6),
+            "sectors": {name: sector.to_dict() for name, sector in self.sectors.items()},
+            "event_ledger": list(self.event_ledger),
+            "current_events": [event.to_dict() for event in self.current_events],
+            "debate_messages": list(self.debate_messages),
+            "proposals": [proposal.to_dict() for proposal in self.proposals],
+            "votes": list(self.votes),
+            "termination": {
+                "episode_ended": self.done,
+                "reason": self.termination_reason,
             },
-            "event_ledger": [e.to_dict() for e in self._event_ledger],
-            "shutdown_counter": self._shutdown_counter,
-            "prosperity_streak": self._prosperity_streak,
+            "last_reward": self.last_reward.to_dict(),
+            "total_reward": round(self.total_reward, 6),
+            "last_total_revenue": round(self.last_total_revenue, 6),
+            "last_total_surplus": round(self.last_total_surplus, 6),
+            "last_total_allocation": round(self.last_total_allocation, 6),
         }
 
-    # ── Internal helpers ────────────────────────────────────────
+    def step(self, action: Any = None) -> StepResult:
+        """
+        Process one phase step.
 
-    def _terminate(
+        A mapping of ``{department: amount}`` remains supported as a legacy
+        full-round shortcut and is converted into direct approved allocations.
+        """
+        if self.done:
+            return self._result({"ignored": True, "reason": "episode_done"})
+
+        if self._is_allocation_mapping(action):
+            return self._run_direct_allocation_round(action)
+
+        info: dict[str, Any] = {"accepted_actions": [], "ignored_actions": [], "rejected_actions": []}
+        for item in self._normalize_actions(action):
+            self._handle_phase_action(item, info)
+
+        self._run_current_system_phase(info)
+        completed_round = self.round
+        self._advance_phase()
+
+        if not self.done and self.phase == Phase.EVENT_REVELATION and self.round != completed_round:
+            self._start_round()
+
+        self.last_info = info
+        return self._result(info)
+
+    def _start_round(self) -> None:
+        self.current_round_crisis = False
+        self.current_events = []
+        self.debate_messages = []
+        self.proposals = []
+        self.votes = []
+        self._submitted_departments = set()
+        self._abstained_departments = set()
+
+        for sector in self.sectors.values():
+            sector.reset_round()
+            sector.update_thresholds(self.population.value, self.config.POP_0)
+
+        self.current_events = self.event_engine.generate_events(
+            sector_names=list(self.config.SECTOR_ORDER)
+        )
+        self.current_round_crisis = self.event_engine.apply_events(
+            self.current_events,
+            self.sectors,
+            self.treasury,
+        )
+        for sector in self.sectors.values():
+            sector.update_thresholds(self.population.value, self.config.POP_0)
+        for event in self.current_events:
+            record = event.to_dict()
+            record["round"] = self.round
+            self.event_ledger.append(record)
+
+    def _handle_phase_action(self, action: Mapping[str, Any], info: dict[str, Any]) -> None:
+        action_type = self._action_type_value(action.get("type"))
+        if action_type not in valid_action_types_for_phase(self.phase):
+            info["ignored_actions"].append({"action": dict(action), "reason": "wrong_phase"})
+            return
+
+        if action_type == ActionType.DEBATE.value:
+            self._handle_debate(action, info)
+        elif action_type == ActionType.PROPOSE_BUDGET.value:
+            self._handle_proposal(action, info)
+        elif action_type == ActionType.ABSTAIN_FROM_PROPOSAL.value:
+            self._handle_proposal_abstention(action, info)
+        elif action_type == ActionType.VOTE.value:
+            self._handle_vote(action, info)
+
+    def _handle_debate(self, action: Mapping[str, Any], info: dict[str, Any]) -> None:
+        message = str(action.get("message", ""))
+        agent_id = str(action.get("agent_id") or action.get("agent") or "anonymous")
+        entry = {"agent_id": agent_id, "message": message}
+        self.debate_messages.append(entry)
+        info["accepted_actions"].append({"type": ActionType.DEBATE.value, **entry})
+
+    def _handle_proposal(self, action: Mapping[str, Any], info: dict[str, Any]) -> None:
+        department = str(action.get("department", ""))
+        agent_id = str(action.get("agent_id") or action.get("agent") or department)
+        amount = action.get("amount")
+
+        rejection_reason = self._proposal_rejection_reason(agent_id, department, amount)
+        if rejection_reason is not None:
+            proposal = self._new_proposal(
+                agent_id=agent_id,
+                department=department,
+                amount=self._safe_float(amount),
+                justification=str(action.get("justification", "")),
+                status=PROPOSAL_STATUS_REJECTED_INVALID,
+                rejection_reason=rejection_reason,
+            )
+            info["rejected_actions"].append(
+                {"action": dict(action), "reason": rejection_reason, "proposal_id": proposal.proposal_id}
+            )
+            return
+
+        proposal = self._new_proposal(
+            agent_id=agent_id,
+            department=department,
+            amount=float(amount),
+            justification=str(action.get("justification", "")),
+        )
+        self._submitted_departments.add(department)
+        info["accepted_actions"].append({"type": ActionType.PROPOSE_BUDGET.value, "proposal_id": proposal.proposal_id})
+
+    def _handle_proposal_abstention(self, action: Mapping[str, Any], info: dict[str, Any]) -> None:
+        department = str(action.get("department") or action.get("agent_id") or action.get("agent") or "")
+        if department not in self.sectors or department in self._submitted_departments:
+            info["ignored_actions"].append({"action": dict(action), "reason": "invalid_abstention"})
+            return
+        self._abstained_departments.add(department)
+        info["accepted_actions"].append({"type": ActionType.ABSTAIN_FROM_PROPOSAL.value, "department": department})
+
+    def _handle_vote(self, action: Mapping[str, Any], info: dict[str, Any]) -> None:
+        proposal_id = str(action.get("proposal_id", ""))
+        proposal = self._proposal_by_id(proposal_id)
+        agent_id = str(action.get("agent_id") or action.get("agent") or "")
+        vote = self._vote_value(action.get("vote"))
+
+        if proposal is None or proposal.status != PROPOSAL_STATUS_PENDING:
+            info["ignored_actions"].append({"action": dict(action), "reason": "proposal_not_votable"})
+            return
+        if not agent_id:
+            info["ignored_actions"].append({"action": dict(action), "reason": "missing_agent_id"})
+            return
+        if agent_id == proposal.agent_id or agent_id == proposal.department:
+            info["rejected_actions"].append({"action": dict(action), "reason": "self_vote"})
+            return
+        if vote is None:
+            info["rejected_actions"].append({"action": dict(action), "reason": "invalid_vote"})
+            return
+        if agent_id in proposal.votes:
+            info["ignored_actions"].append({"action": dict(action), "reason": "duplicate_vote"})
+            return
+
+        proposal.votes[agent_id] = vote
+        self.votes.append({"proposal_id": proposal_id, "agent_id": agent_id, "vote": vote})
+        info["accepted_actions"].append({"type": ActionType.VOTE.value, "proposal_id": proposal_id, "agent_id": agent_id, "vote": vote})
+
+    def _run_current_system_phase(self, info: dict[str, Any]) -> None:
+        if self.phase == Phase.BUDGET_EXECUTION:
+            self._tally_votes()
+            critical_failed = self._execute_approved_budgets()
+            if critical_failed:
+                self._finish_round(critical_failed=True, terminate_immediately=True)
+                info["termination_reason"] = self.termination_reason
+        elif self.phase == Phase.CONSUMPTION_AND_EVENT_IMPACT and not self.done:
+            self._compute_consumption()
+        elif self.phase == Phase.REVENUE_CALCULATION and not self.done:
+            self._compute_revenue()
+            self.treasury.credit(self.last_total_revenue)
+        elif self.phase == Phase.SURPLUS_ROLLOVER and not self.done:
+            self.treasury.credit(self.last_total_surplus)
+            self.treasury.apply_baseline_tax()
+        elif self.phase == Phase.TERMINATION_CHECK and not self.done:
+            self._finish_round(critical_failed=False)
+            info["termination_reason"] = self.termination_reason
+
+    def _run_direct_allocation_round(self, allocations: Mapping[str, Any]) -> StepResult:
+        if self.phase != Phase.EVENT_REVELATION:
+            self.phase = Phase.EVENT_REVELATION
+            self._start_round()
+
+        for proposal in self.proposals:
+            proposal.status = PROPOSAL_STATUS_REJECTED
+        self.proposals = []
+        for department in self.config.SECTOR_ORDER:
+            amount = float(allocations.get(department, 0.0))
+            proposal = self._new_proposal(
+                agent_id=department,
+                department=department,
+                amount=amount,
+                status=PROPOSAL_STATUS_APPROVED,
+            )
+            self.sectors[department].allocate(proposal.amount)
+
+        critical_failed = any(sector.is_critical_failure(self.population.value) for sector in self.sectors.values())
+        if not critical_failed:
+            self.last_total_allocation = sum(sector.allocation for sector in self.sectors.values())
+            self.treasury.balance -= self.last_total_allocation
+            self._compute_consumption()
+            self._compute_revenue()
+            self.treasury.credit(self.last_total_revenue)
+            self.treasury.credit(self.last_total_surplus)
+            self.treasury.apply_baseline_tax()
+
+        self._finish_round(critical_failed=critical_failed, completed_round=self.round)
+        info = {
+            "accepted_actions": [{"type": "DIRECT_ALLOCATION"}],
+            "ignored_actions": [],
+            "rejected_actions": [],
+            "termination_reason": self.termination_reason,
+        }
+        self.last_info = info
+        if not self.done:
+            self.round += 1
+            self.phase = Phase.EVENT_REVELATION
+            self._start_round()
+        return self._result(info, completed_round=self.round - 1 if not self.done else self.round)
+
+    def _execute_approved_budgets(self) -> bool:
+        for sector in self.sectors.values():
+            sector.allocate(0.0)
+
+        for proposal in self.proposals:
+            if proposal.status == PROPOSAL_STATUS_APPROVED:
+                self.sectors[proposal.department].allocate(
+                    self.sectors[proposal.department].allocation + proposal.amount
+                )
+
+        critical_failed = any(sector.is_critical_failure(self.population.value) for sector in self.sectors.values())
+        if critical_failed:
+            self.last_total_allocation = sum(sector.allocation for sector in self.sectors.values())
+            return True
+
+        self.last_total_allocation = 0.0
+        for sector in self.sectors.values():
+            self.last_total_allocation += sector.allocation
+            self.treasury.balance -= sector.allocation
+        return False
+
+    def _tally_votes(self) -> None:
+        remaining_treasury = self.treasury.balance
+        for proposal in self.proposals:
+            if proposal.status != PROPOSAL_STATUS_PENDING:
+                continue
+            yes_votes = sum(1 for vote in proposal.votes.values() if vote == VoteChoice.YES.value)
+            no_votes = sum(1 for vote in proposal.votes.values() if vote == VoteChoice.NO.value)
+            if proposal.amount > remaining_treasury:
+                proposal.status = PROPOSAL_STATUS_REJECTED
+                proposal.rejection_reason = "exceeds_remaining_treasury"
+            elif yes_votes > no_votes:
+                proposal.status = PROPOSAL_STATUS_APPROVED
+                remaining_treasury -= proposal.amount
+            else:
+                proposal.status = PROPOSAL_STATUS_REJECTED
+
+    def _compute_consumption(self) -> None:
+        self.last_total_surplus = 0.0
+        for sector in self.sectors.values():
+            self.last_total_surplus += sector.compute_consumption()
+
+    def _compute_revenue(self) -> None:
+        self.last_total_revenue = 0.0
+        for sector in self.sectors.values():
+            revenue = sector.compute_revenue(self.population.value, self.productivity.value)
+            if revenue is not None:
+                self.last_total_revenue += revenue
+
+    def _finish_round(
         self,
-        alloc: dict[str, float],
-        events: list[Event],
-        crisis: bool,
-        reason: str,
+        *,
         critical_failed: bool,
-    ) -> StepResult:
-        """Build a StepResult for an immediately-terminating round."""
-        cfg = self.config
-        self._done = True
-        self._termination_reason = reason
+        terminate_immediately: bool = False,
+        completed_round: int | None = None,
+    ) -> None:
+        completed_round = completed_round or self.round
+        if critical_failed:
+            self.done = True
+            self.termination_reason = TERMINATION_CRITICAL_FAILURE
+        else:
+            revenue_factors = [sector.revenue_factor_value for sector in self.sectors.values()]
+            self.productivity.update(revenue_factors)
+            self.population.update(self.productivity.value, self.current_round_crisis)
+            self._update_shutdown_counter()
+            self._check_standard_termination()
 
-        total_alloc = sum(alloc.values())
-
-        # On critical failure no revenue is generated (spec 04)
-        total_revenue = 0.0
-
-        # Prosperity at termination = (Treasury + Revenue) / Population
-        # Revenue is 0 on critical failure
-        reward = compute_reward(
-            sectors=self._sectors,
-            total_revenue=total_revenue,
-            population=self._population.value,
-            productivity=self._productivity.value,
-            round_num=self._round,
+        prosperity = self.last_total_revenue / max(self.population.value, 1)
+        self.last_reward = compute_reward(
+            sectors=self.sectors,
+            total_revenue=self.last_total_revenue,
+            population=self.population.value,
+            productivity=self.productivity.value,
+            round_num=completed_round,
             critical_failed=critical_failed,
-            productivity_bonus_scale=cfg.PRODUCTIVITY_BONUS_SCALE,
-            survival_bonus_per_round=cfg.SURVIVAL_BONUS_PER_ROUND,
-            over_alloc_penalty_val=cfg.OVER_ALLOC_PENALTY,
-            under_alloc_penalty_val=cfg.UNDER_ALLOC_PENALTY,
-            critical_penalty_val=cfg.CRITICAL_PENALTY,
+            productivity_bonus_scale=self.config.PRODUCTIVITY_BONUS_SCALE,
+            survival_bonus_per_round=self.config.SURVIVAL_BONUS_PER_ROUND,
+            over_alloc_penalty_val=self.config.OVER_ALLOC_PENALTY,
+            under_alloc_penalty_val=self.config.UNDER_ALLOC_PENALTY,
+            critical_penalty_val=self.config.CRITICAL_PENALTY,
         )
+        if self.termination_reason == TERMINATION_BANKRUPTCY:
+            self.last_reward.critical_penalty = self.config.BANKRUPTCY_PENALTY
+        self.total_reward += self.last_reward.total
 
-        year, quarter = self._time_display()
+        if terminate_immediately:
+            self.phase = Phase.BUDGET_EXECUTION
+        if not self.done and self.config.PROSPERITY_THRESHOLD is not None:
+            if prosperity >= self.config.PROSPERITY_THRESHOLD:
+                self.prosperity_streak += 1
+            else:
+                self.prosperity_streak = 0
+            if self.prosperity_streak >= self.config.PROSPERITY_STREAK:
+                self.done = True
+                self.termination_reason = TERMINATION_PROSPERITY
 
+    def _check_standard_termination(self) -> None:
+        if self.shutdown_counter >= self.config.SHUTDOWN_THRESHOLD:
+            self.done = True
+            self.termination_reason = TERMINATION_SHUTDOWN
+        elif self.treasury.is_bankrupt():
+            self.done = True
+            self.termination_reason = TERMINATION_BANKRUPTCY
+        elif self.round >= self.config.MAX_ROUNDS:
+            self.done = True
+            self.termination_reason = TERMINATION_MAX_ROUNDS
+
+    def _update_shutdown_counter(self) -> None:
+        if self.last_total_allocation == 0:
+            self.shutdown_counter += 1
+        else:
+            self.shutdown_counter = 0
+
+    def _advance_phase(self) -> None:
+        if self.done:
+            return
+        if self.phase == Phase.TERMINATION_CHECK:
+            self.round += 1
+            self.phase = Phase.EVENT_REVELATION
+            return
+        self.phase = Phase(int(self.phase) + 1)
+
+    def _new_proposal(
+        self,
+        *,
+        agent_id: str,
+        department: str,
+        amount: float,
+        justification: str = "",
+        status: str = PROPOSAL_STATUS_PENDING,
+        rejection_reason: str | None = None,
+    ) -> Proposal:
+        self._proposal_counter += 1
+        proposal = Proposal(
+            proposal_id=f"r{self.round}-p{self._proposal_counter}",
+            agent_id=agent_id,
+            department=department,
+            amount=amount,
+            justification=justification,
+            status=status,
+            rejection_reason=rejection_reason,
+        )
+        self.proposals.append(proposal)
+        return proposal
+
+    def _proposal_rejection_reason(self, agent_id: str, department: str, amount: Any) -> str | None:
+        amount_value = self._safe_float(amount)
+        if department not in self.sectors:
+            return "unknown_department"
+        if agent_id != department:
+            return "wrong_department"
+        if department in self._submitted_departments:
+            return "duplicate_proposal"
+        if amount_value < 0 or math.isnan(amount_value) or math.isinf(amount_value):
+            return "invalid_amount"
+        if amount_value > self.treasury.balance:
+            return "exceeds_treasury"
+        return None
+
+    def _proposal_by_id(self, proposal_id: str) -> Proposal | None:
+        return next((proposal for proposal in self.proposals if proposal.proposal_id == proposal_id), None)
+
+    def _result(self, info: dict[str, Any], completed_round: int | None = None) -> StepResult:
+        observation = self.state()
+        if completed_round is not None:
+            year, quarter = self._year_quarter(completed_round)
+            observation["round"] = completed_round
+            observation["year"] = year
+            observation["quarter"] = quarter
         return StepResult(
-            round_num=self._round,
-            year=year,
-            quarter=quarter,
-            treasury=self._treasury.balance,
-            allocations=alloc,
-            revenue_factors={n: 0.0 for n in self._sectors},
-            revenues={n: 0.0 for n in self._sectors},
-            consumptions={n: 0.0 for n in self._sectors},
-            demands={n: s.demand for n, s in self._sectors.items()},
-            total_revenue=0.0,
-            total_allocation=total_alloc,
-            surplus_returned=0.0,
-            population=self._population.value,
-            productivity=self._productivity.value,
-            reward=reward,
-            events=events,
-            crisis_occurred=crisis,
-            done=True,
-            termination_reason=reason,
+            observation=observation,
+            reward=self.last_reward,
+            done=self.done,
+            info={
+                **info,
+                "termination_reason": self.termination_reason,
+                "crisis_occurred": self.current_round_crisis,
+            },
         )
 
-    def _build_observation(self, events: list[Event], crisis: bool) -> dict:
-        """Build an observation dict for the initial state (after reset)."""
-        return {
-            "round_num": self._round,
-            "year": 1,
-            "quarter": 1,
-            "treasury": self._treasury.balance,
-            "population": self._population.value,
-            "productivity": self._productivity.value,
-            "sectors": {n: s.to_dict() for n, s in self._sectors.items()},
-            "events": [e.to_dict() for e in events],
-            "crisis_occurred": crisis,
-            "done": False,
-            "termination_reason": None,
-        }
+    def _normalize_actions(self, action: Any) -> list[Mapping[str, Any]]:
+        if action is None:
+            return []
+        if hasattr(action, "to_dict"):
+            return [action.to_dict()]
+        if isinstance(action, Mapping):
+            return [action]
+        if isinstance(action, Iterable) and not isinstance(action, (str, bytes)):
+            normalized = []
+            for item in action:
+                if hasattr(item, "to_dict"):
+                    normalized.append(item.to_dict())
+                elif isinstance(item, Mapping):
+                    normalized.append(item)
+            return normalized
+        return []
 
-    def _time_display(self) -> tuple[int, int]:
-        """Convert round number to (year, quarter)."""
-        year = (self._round - 1) // 4 + 1
-        quarter = (self._round - 1) % 4 + 1
+    def _is_allocation_mapping(self, action: Any) -> bool:
+        return (
+            isinstance(action, Mapping)
+            and "type" not in action
+            and bool(action)
+            and set(action).issubset(set(self.config.SECTOR_ORDER))
+        )
+
+    def _action_type_value(self, action_type: Any) -> str:
+        if isinstance(action_type, StrEnum):
+            return action_type.value
+        return str(action_type)
+
+    def _vote_value(self, vote: Any) -> str | None:
+        value = vote.value if isinstance(vote, StrEnum) else str(vote)
+        return value if value in {choice.value for choice in VoteChoice} else None
+
+    def _safe_float(self, value: Any) -> float:
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return math.nan
+
+    def _year_quarter(self, round_num: int) -> tuple[int, int]:
+        year = (round_num - 1) // 4 + 1
+        quarter = (round_num - 1) % 4 + 1
         return year, quarter

--- a/tests/integration/test_game_loop.py
+++ b/tests/integration/test_game_loop.py
@@ -42,6 +42,14 @@ def vote(agent_id: str, proposal_id: str, choice: VoteChoice = VoteChoice.YES) -
     return {"type": ActionType.VOTE, "agent_id": agent_id, "proposal_id": proposal_id, "vote": choice}
 
 
+def abstain_from_proposal(department: str) -> dict:
+    return {
+        "type": ActionType.ABSTAIN_FROM_PROPOSAL,
+        "agent_id": department,
+        "department": department,
+    }
+
+
 def advance_to_phase(game: NationGame, phase: Phase) -> None:
     while game.phase < phase and not game.done:
         game.step()
@@ -66,6 +74,13 @@ def run_phase_loop_round(game: NationGame) -> None:
     game.step()
     submit_safe_proposals(game)
     approve_all_pending_proposals(game)
+    while game.phase != Phase.EVENT_REVELATION and not game.done:
+        game.step()
+
+
+def run_all_abstain_round(game: NationGame) -> None:
+    advance_to_phase(game, Phase.PROPOSAL)
+    game.step([abstain_from_proposal(department) for department in DEPARTMENTS])
     while game.phase != Phase.EVENT_REVELATION and not game.done:
         game.step()
 
@@ -156,6 +171,16 @@ def test_invalid_proposal_over_treasury_is_rejected() -> None:
     assert game.proposals[0].status == PROPOSAL_STATUS_REJECTED_INVALID
 
 
+def test_duplicate_proposal_is_ignored() -> None:
+    game = make_game()
+    advance_to_phase(game, Phase.PROPOSAL)
+
+    result = game.step([proposal("Health", amount=90), proposal("Health", amount=95)])
+
+    assert len(game.proposals) == 1
+    assert result.info["ignored_actions"][0]["reason"] == "duplicate_proposal"
+
+
 def test_agents_cannot_propose_for_another_department() -> None:
     game = make_game()
     advance_to_phase(game, Phase.PROPOSAL)
@@ -194,6 +219,8 @@ def test_tie_vote_rejects_proposal() -> None:
 
     assert health_proposal.status == PROPOSAL_STATUS_REJECTED
     assert game.sectors["Health"].allocation == 0
+    assert not game.done
+    assert game.termination_reason is None
 
 
 def test_approved_proposal_debits_treasury() -> None:
@@ -220,6 +247,51 @@ def test_rejected_proposal_allocates_zero() -> None:
 
     assert health_proposal.status == PROPOSAL_STATUS_REJECTED
     assert game.sectors["Health"].allocation == 0
+    assert not game.done
+    assert game.termination_reason is None
+
+
+def test_abstain_from_proposal_action_is_accepted() -> None:
+    game = make_game()
+    advance_to_phase(game, Phase.PROPOSAL)
+
+    result = game.step(abstain_from_proposal("Health"))
+
+    assert result.info["accepted_actions"][0]["type"] == ActionType.ABSTAIN_FROM_PROPOSAL
+    assert game.proposals == []
+
+
+def test_two_all_abstain_rounds_trigger_shutdown() -> None:
+    game = make_game()
+
+    run_all_abstain_round(game)
+    assert not game.done
+    assert game.shutdown_counter == 1
+
+    run_all_abstain_round(game)
+    assert game.done
+    assert game.termination_reason == "SHUTDOWN"
+
+
+def test_sequential_treasury_depletion_rejects_later_proposal() -> None:
+    game = make_game()
+    advance_to_phase(game, Phase.PROPOSAL)
+    game.step([proposal("Social", amount=900), proposal("Health", amount=900)])
+    social_proposal = next(item for item in game.proposals if item.department == "Social")
+    health_proposal = next(item for item in game.proposals if item.department == "Health")
+
+    game.step([
+        vote("Agriculture", social_proposal.proposal_id),
+        vote("Defense", social_proposal.proposal_id),
+        vote("Agriculture", health_proposal.proposal_id),
+        vote("Defense", health_proposal.proposal_id),
+    ])
+    game.step()
+
+    assert social_proposal.status == PROPOSAL_STATUS_APPROVED
+    assert health_proposal.status == PROPOSAL_STATUS_REJECTED
+    assert health_proposal.rejection_reason == "exceeds_remaining_treasury"
+    assert not game.done
 
 
 def test_critical_under_allocation_terminates_episode() -> None:
@@ -231,6 +303,27 @@ def test_critical_under_allocation_terminates_episode() -> None:
 
     assert result.done
     assert result.termination_reason == "CRITICAL_FAILURE"
+
+
+def test_critical_failure_after_revenue_round_uses_zero_current_revenue() -> None:
+    game = make_game()
+    safe_allocations = {
+        department: baseline * 1.3
+        for department, baseline in game.config.SECTOR_BASELINES.items()
+    }
+    first_result = game.step(safe_allocations)
+    assert first_result.total_revenue > 0
+
+    advance_to_phase(game, Phase.PROPOSAL)
+    game.step(proposal("Health", amount=1))
+    health_proposal = game.proposals[0]
+    game.step([vote("Defense", health_proposal.proposal_id), vote("Commerce", health_proposal.proposal_id)])
+    result = game.step()
+
+    assert result.done
+    assert result.termination_reason == "CRITICAL_FAILURE"
+    assert game.last_total_revenue == 0
+    assert result.reward.base_reward == 0
 
 
 def test_bankruptcy_terminates_episode() -> None:

--- a/tests/integration/test_game_loop.py
+++ b/tests/integration/test_game_loop.py
@@ -1,0 +1,265 @@
+from dataclasses import replace
+
+import pytest
+
+from core.config import GameConfig
+from core.game import (
+    PROPOSAL_STATUS_APPROVED,
+    PROPOSAL_STATUS_REJECTED,
+    PROPOSAL_STATUS_REJECTED_INVALID,
+    NationGame,
+)
+from schemas.actions import ActionType, VoteChoice
+from schemas.phases import Phase
+
+
+DEPARTMENTS = ("Social", "Agriculture", "Health", "Education", "Defense", "Commerce")
+
+
+def make_game(seed: int = 7, **config_overrides) -> NationGame:
+    config = replace(GameConfig.from_json(), **config_overrides) if config_overrides else GameConfig.from_json()
+    game = NationGame(config=config, seed=seed)
+    game.event_engine._distribution = {"no_event": 1.0}
+    game.reset()
+    return game
+
+
+def debate(agent_id: str = "Health") -> dict:
+    return {"type": ActionType.DEBATE, "agent_id": agent_id, "message": "Public priority signal"}
+
+
+def proposal(department: str, amount: float | None = None) -> dict:
+    return {
+        "type": ActionType.PROPOSE_BUDGET,
+        "agent_id": department,
+        "department": department,
+        "amount": amount if amount is not None else 1.3 * GameConfig.from_json().SECTOR_BASELINES[department],
+        "justification": "Fund expected demand",
+    }
+
+
+def vote(agent_id: str, proposal_id: str, choice: VoteChoice = VoteChoice.YES) -> dict:
+    return {"type": ActionType.VOTE, "agent_id": agent_id, "proposal_id": proposal_id, "vote": choice}
+
+
+def advance_to_phase(game: NationGame, phase: Phase) -> None:
+    while game.phase < phase and not game.done:
+        game.step()
+
+
+def submit_safe_proposals(game: NationGame) -> None:
+    advance_to_phase(game, Phase.PROPOSAL)
+    game.step([proposal(department) for department in DEPARTMENTS])
+
+
+def approve_all_pending_proposals(game: NationGame) -> None:
+    advance_to_phase(game, Phase.VOTING)
+    actions = []
+    for item in game.proposals:
+        for department in DEPARTMENTS:
+            if department != item.department:
+                actions.append(vote(department, item.proposal_id))
+    game.step(actions)
+
+
+def run_phase_loop_round(game: NationGame) -> None:
+    game.step()
+    submit_safe_proposals(game)
+    approve_all_pending_proposals(game)
+    while game.phase != Phase.EVENT_REVELATION and not game.done:
+        game.step()
+
+
+def test_reset_creates_round_1_phase_1_state() -> None:
+    game = make_game()
+
+    state = game.state()
+
+    assert state["round"] == 1
+    assert state["phase"] == Phase.EVENT_REVELATION
+    assert state["treasury"] == 1000
+
+
+def test_phase_transitions_follow_1_through_9() -> None:
+    game = make_game()
+    seen = [game.phase]
+
+    game.step()
+    seen.append(game.phase)
+    game.step()
+    seen.append(game.phase)
+    game.step([proposal(department) for department in DEPARTMENTS])
+    seen.append(game.phase)
+    approve_all_pending_proposals(game)
+    seen.append(game.phase)
+    while game.phase != Phase.EVENT_REVELATION:
+        game.step()
+        seen.append(game.phase)
+
+    assert seen[:9] == [Phase(index) for index in range(1, 10)]
+    assert game.round == 2
+
+
+def test_debate_action_only_accepted_in_phase_2() -> None:
+    game = make_game()
+
+    phase_1_result = game.step(debate())
+    phase_2_result = game.step(debate())
+
+    assert phase_1_result.info["ignored_actions"][0]["reason"] == "wrong_phase"
+    assert phase_2_result.info["accepted_actions"][0]["type"] == ActionType.DEBATE
+    assert len(game.debate_messages) == 1
+
+
+def test_proposal_action_only_accepted_in_phase_3() -> None:
+    game = make_game()
+
+    wrong_phase_result = game.step(proposal("Health"))
+    advance_to_phase(game, Phase.PROPOSAL)
+    accepted_result = game.step(proposal("Health"))
+
+    assert wrong_phase_result.info["ignored_actions"][0]["reason"] == "wrong_phase"
+    assert accepted_result.info["accepted_actions"][0]["type"] == ActionType.PROPOSE_BUDGET
+
+
+def test_vote_action_only_accepted_in_phase_4() -> None:
+    game = make_game()
+    advance_to_phase(game, Phase.PROPOSAL)
+    wrong_phase_result = game.step(vote("Health", "missing"))
+
+    game = make_game()
+    submit_safe_proposals(game)
+    proposal_id = game.proposals[0].proposal_id
+
+    accepted_result = game.step(vote("Health", proposal_id))
+
+    assert wrong_phase_result.info["ignored_actions"][0]["reason"] == "wrong_phase"
+    assert accepted_result.info["accepted_actions"][0]["type"] == ActionType.VOTE
+
+
+def test_wrong_phase_action_is_ignored() -> None:
+    game = make_game()
+
+    result = game.step({"type": ActionType.VOTE, "agent_id": "Health", "proposal_id": "missing", "vote": VoteChoice.YES})
+
+    assert result.info["ignored_actions"][0]["reason"] == "wrong_phase"
+    assert game.votes == []
+
+
+def test_invalid_proposal_over_treasury_is_rejected() -> None:
+    game = make_game()
+    advance_to_phase(game, Phase.PROPOSAL)
+
+    result = game.step(proposal("Health", amount=game.treasury.balance + 1))
+
+    assert result.info["rejected_actions"][0]["reason"] == "exceeds_treasury"
+    assert game.proposals[0].status == PROPOSAL_STATUS_REJECTED_INVALID
+
+
+def test_agents_cannot_propose_for_another_department() -> None:
+    game = make_game()
+    advance_to_phase(game, Phase.PROPOSAL)
+    action = proposal("Health")
+    action["agent_id"] = "Defense"
+
+    result = game.step(action)
+
+    assert result.info["rejected_actions"][0]["reason"] == "wrong_department"
+    assert game.proposals[0].status == PROPOSAL_STATUS_REJECTED_INVALID
+
+
+def test_self_vote_is_rejected() -> None:
+    game = make_game()
+    submit_safe_proposals(game)
+    health_proposal = next(item for item in game.proposals if item.department == "Health")
+
+    result = game.step(vote("Health", health_proposal.proposal_id))
+
+    assert result.info["rejected_actions"][0]["reason"] == "self_vote"
+    assert health_proposal.votes == {}
+
+
+def test_tie_vote_rejects_proposal() -> None:
+    game = make_game()
+    advance_to_phase(game, Phase.PROPOSAL)
+    game.step(proposal("Health", amount=90))
+    health_proposal = game.proposals[0]
+
+    game.step([
+        vote("Defense", health_proposal.proposal_id, VoteChoice.YES),
+        vote("Commerce", health_proposal.proposal_id, VoteChoice.NO),
+        vote("Social", health_proposal.proposal_id, VoteChoice.ABSTAIN),
+    ])
+    game.step()
+
+    assert health_proposal.status == PROPOSAL_STATUS_REJECTED
+    assert game.sectors["Health"].allocation == 0
+
+
+def test_approved_proposal_debits_treasury() -> None:
+    game = make_game()
+    submit_safe_proposals(game)
+    approve_all_pending_proposals(game)
+
+    before_execution = game.treasury.balance
+    approved_total = sum(item.amount for item in game.proposals)
+    game.step()
+
+    assert all(item.status == PROPOSAL_STATUS_APPROVED for item in game.proposals)
+    assert game.treasury.balance == pytest.approx(before_execution - approved_total)
+
+
+def test_rejected_proposal_allocates_zero() -> None:
+    game = make_game()
+    advance_to_phase(game, Phase.PROPOSAL)
+    game.step(proposal("Health", amount=90))
+    health_proposal = game.proposals[0]
+    game.step([vote("Defense", health_proposal.proposal_id, VoteChoice.NO)])
+
+    game.step()
+
+    assert health_proposal.status == PROPOSAL_STATUS_REJECTED
+    assert game.sectors["Health"].allocation == 0
+
+
+def test_critical_under_allocation_terminates_episode() -> None:
+    game = make_game()
+    allocations = dict(game.config.SECTOR_BASELINES)
+    allocations["Defense"] = 30
+
+    result = game.step(allocations)
+
+    assert result.done
+    assert result.termination_reason == "CRITICAL_FAILURE"
+
+
+def test_bankruptcy_terminates_episode() -> None:
+    game = make_game()
+    game.treasury.balance = 1
+    critical_allocations = {
+        department: baseline * game.config.CRITICAL_RATIO
+        for department, baseline in game.config.SECTOR_BASELINES.items()
+    }
+
+    result = game.step(critical_allocations)
+
+    assert result.done
+    assert result.termination_reason == "BANKRUPTCY"
+    assert result.treasury <= 0
+
+
+def test_max_rounds_terminates_episode() -> None:
+    game = make_game(MAX_ROUNDS=1)
+
+    run_phase_loop_round(game)
+
+    assert game.done
+    assert game.termination_reason == "MAX_ROUNDS"
+
+
+def test_seeded_reset_is_deterministic() -> None:
+    first = NationGame(seed=123).reset(seed=123)
+    second = NationGame(seed=123).reset(seed=123)
+
+    assert first["event_ledger"] == second["event_ledger"]
+    assert first["sectors"] == second["sectors"]


### PR DESCRIPTION
## Summary
- Implements `NationGame` as the playable core orchestration layer across the 9-phase round structure, including event revelation, debate, proposal submission, voting, budget execution, consumption, revenue calculation, surplus rollover, and termination checks.
- Adds schema-based action handling for debate, proposals, proposal abstentions, and votes with phase enforcement, wrong-phase ignores, invalid proposal rejection, department ownership checks, explicit abstentions, self-vote rejection, tie rejection, and public vote/proposal state.
- Wires the already-merged core primitives together for treasury, events, sectors, productivity, population, and reward calculation while preserving the legacy direct allocation shortcut for existing core tests.
- Adds integration coverage for reset state, phase transitions, phase-gated actions, invalid proposals, self-votes, tie votes, approved/rejected allocation effects, critical failure, bankruptcy, max rounds, and seeded determinism.

## Test plan
- `uv sync --extra dev` could not be run in this shell because `uv` was not installed when verified.
- `uv run pytest tests/unit` could not be run because `uv` was not installed when verified.
- `uv run pytest tests/integration/test_game_loop.py` could not be run because `uv` was not installed when verified.
- `uv run pytest` could not be run because `uv` was not installed when verified.
- Fallback checks run locally:
  - `/usr/local/bin/python3.11 -m py_compile core/game.py tests/integration/test_game_loop.py`
  - Manual Python 3.11 smoke execution of all new integration test functions with a lightweight pytest stub.
  - Manual Python 3.11 smoke execution of no-fixture unit test functions with a lightweight pytest stub.

## Out of scope
- OpenEnv/server wrapper integration.
- LLM adapters and agent implementations.
- Telemetry persistence beyond useful returned `info` dictionaries.
- Training scripts and RL pipelines.
- UI or Hugging Face Space work.

## Notes
- The branch intentionally excludes unrelated local working-tree changes currently present under `.sisyphus`, `.cursor`, and `uv.lock`.

Made with [Cursor](https://cursor.com)