### PR TITLE
Implement parliamentary action resolution interface

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -16,6 +16,13 @@ No framework dependencies.  The entire game can be run with::
 from .config import DEFAULT_CONFIG, GameConfig
 from .events import Event, EventEngine
 from .game import NationGame, StepResult
+from .parliament import (
+    DebateMessage,
+    ParliamentRoundState,
+    Proposal,
+    ResolutionResult,
+    VoteRecord,
+)
 from .population import PopulationTracker
 from .productivity import ProductivityTracker
 from .revenue import calculate_revenue, compute_thresholds, revenue_factor
@@ -26,6 +33,11 @@ from .treasury import Treasury
 __all__ = [
     "NationGame",
     "StepResult",
+    "ParliamentRoundState",
+    "Proposal",
+    "VoteRecord",
+    "DebateMessage",
+    "ResolutionResult",
     "GameConfig",
     "DEFAULT_CONFIG",
     "Sector",

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -20,6 +20,7 @@ from .parliament import (
     DebateMessage,
     ParliamentRoundState,
     Proposal,
+    ProposalAbstention,
     ResolutionResult,
     VoteRecord,
 )
@@ -35,6 +36,7 @@ __all__ = [
     "StepResult",
     "ParliamentRoundState",
     "Proposal",
+    "ProposalAbstention",
     "VoteRecord",
     "DebateMessage",
     "ResolutionResult",

--- a/core/parliament.py
+++ b/core/parliament.py
@@ -1,0 +1,277 @@
+"""Parliamentary action collection and budget resolution.
+
+This module is a narrow adapter between phased parliamentary actions and the
+round-level allocation mapping accepted by :class:`core.game.NationGame`.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any, Mapping
+
+from schemas.actions import ActionType, VoteChoice
+from schemas.phases import Phase
+
+
+PROPOSAL_STATUS_APPROVED = "approved"
+PROPOSAL_STATUS_REJECTED_ALL_ABSTAIN = "rejected_all_abstain"
+PROPOSAL_STATUS_REJECTED_TIE = "rejected_tie"
+PROPOSAL_STATUS_REJECTED_MAJORITY = "rejected_majority"
+PROPOSAL_STATUS_REJECTED_OVER_BUDGET = "rejected_exceeds_remaining_treasury"
+
+
+@dataclass(frozen=True, slots=True)
+class Proposal:
+    """Public budget request submitted by a minister for their department."""
+
+    proposal_id: str
+    agent_id: str
+    department: str
+    amount: float
+    justification: str = ""
+    submitted_order: int = 0
+
+
+@dataclass(frozen=True, slots=True)
+class VoteRecord:
+    """Public vote cast by one agent on one proposal."""
+
+    proposal_id: str
+    agent_id: str
+    vote: VoteChoice
+    cast_order: int = 0
+
+
+@dataclass(frozen=True, slots=True)
+class DebateMessage:
+    """Public debate message visible to all agents."""
+
+    agent_id: str
+    message: str
+    submitted_order: int = 0
+
+
+@dataclass(frozen=True, slots=True)
+class ResolutionResult:
+    """Resolved parliamentary round output for the core game engine."""
+
+    allocations: dict[str, float]
+    approved_proposal_ids: list[str]
+    rejected_proposal_ids: list[str]
+    proposal_outcomes: dict[str, str]
+    vote_counts: dict[str, dict[str, int]]
+    remaining_treasury: float
+    proposals: list[Proposal]
+    votes: list[VoteRecord]
+    debate_messages: list[DebateMessage]
+
+
+@dataclass(slots=True)
+class ParliamentRoundState:
+    """Collects debate, proposal, and vote actions for a single round."""
+
+    round_number: int
+    treasury_at_start: float
+    agent_departments: Mapping[str, str]
+    proposals: list[Proposal] = field(default_factory=list)
+    votes: list[VoteRecord] = field(default_factory=list)
+    debate_messages: list[DebateMessage] = field(default_factory=list)
+    _proposal_counter: int = 0
+    _vote_counter: int = 0
+    _debate_counter: int = 0
+    _proposing_agents: set[str] = field(default_factory=set)
+    _votes_by_proposal_agent: set[tuple[str, str]] = field(default_factory=set)
+
+    def collect_action(self, phase: Phase, action: Any) -> Proposal | VoteRecord | DebateMessage | None:
+        """Collect one structured action if it belongs to the supplied phase."""
+
+        data = _action_to_mapping(action)
+        action_type = _enum_value(data.get("type"))
+
+        if Phase(phase) == Phase.DEBATE and action_type == ActionType.DEBATE.value:
+            return self.submit_debate(
+                agent_id=str(data.get("agent_id") or data.get("agent") or "anonymous"),
+                message=str(data.get("message", "")),
+            )
+        if Phase(phase) == Phase.PROPOSAL and action_type == ActionType.PROPOSE_BUDGET.value:
+            return self.submit_proposal(
+                agent_id=str(data.get("agent_id") or data.get("agent") or ""),
+                department=str(data.get("department", "")),
+                amount=data.get("amount"),
+                justification=str(data.get("justification", "")),
+            )
+        if Phase(phase) == Phase.VOTING and action_type == ActionType.VOTE.value:
+            return self.submit_vote(
+                agent_id=str(data.get("agent_id") or data.get("agent") or ""),
+                proposal_id=str(data.get("proposal_id", "")),
+                vote=data.get("vote"),
+            )
+        return None
+
+    def submit_debate(self, agent_id: str, message: str) -> DebateMessage:
+        """Record a public debate message."""
+
+        self._debate_counter += 1
+        debate_message = DebateMessage(
+            agent_id=agent_id,
+            message=message,
+            submitted_order=self._debate_counter,
+        )
+        self.debate_messages.append(debate_message)
+        return debate_message
+
+    def submit_proposal(
+        self,
+        agent_id: str,
+        department: str,
+        amount: Any,
+        justification: str = "",
+    ) -> Proposal:
+        """Validate and record a proposal for the agent's assigned department."""
+
+        if agent_id in self._proposing_agents:
+            raise ValueError("duplicate_proposal")
+        if self.agent_departments.get(agent_id) != department:
+            raise ValueError("wrong_department")
+
+        amount_value = _validate_amount(amount)
+        if amount_value > self.treasury_at_start:
+            raise ValueError("exceeds_treasury")
+
+        self._proposal_counter += 1
+        proposal = Proposal(
+            proposal_id=f"r{self.round_number}-p{self._proposal_counter}",
+            agent_id=agent_id,
+            department=department,
+            amount=amount_value,
+            justification=justification,
+            submitted_order=self._proposal_counter,
+        )
+        self.proposals.append(proposal)
+        self._proposing_agents.add(agent_id)
+        return proposal
+
+    def submit_vote(self, agent_id: str, proposal_id: str, vote: Any) -> VoteRecord:
+        """Validate and record a public vote on a proposal."""
+
+        proposal = self._proposal_by_id(proposal_id)
+        if proposal is None:
+            raise ValueError("proposal_not_found")
+        if agent_id == proposal.agent_id:
+            raise ValueError("self_vote")
+
+        vote_key = (proposal_id, agent_id)
+        if vote_key in self._votes_by_proposal_agent:
+            raise ValueError("duplicate_vote")
+
+        vote_choice = _validate_vote(vote)
+        self._vote_counter += 1
+        vote_record = VoteRecord(
+            proposal_id=proposal_id,
+            agent_id=agent_id,
+            vote=vote_choice,
+            cast_order=self._vote_counter,
+        )
+        self.votes.append(vote_record)
+        self._votes_by_proposal_agent.add(vote_key)
+        return vote_record
+
+    def resolve(self) -> ResolutionResult:
+        """Resolve proposal outcomes into a ``{department: allocation}`` mapping."""
+
+        allocations = {department: 0.0 for department in self.agent_departments.values()}
+        proposal_outcomes: dict[str, str] = {}
+        vote_counts: dict[str, dict[str, int]] = {}
+        approved_proposal_ids: list[str] = []
+        rejected_proposal_ids: list[str] = []
+        remaining_treasury = float(self.treasury_at_start)
+
+        for proposal in self.proposals:
+            counts = self._vote_counts_for(proposal.proposal_id)
+            vote_counts[proposal.proposal_id] = counts
+            outcome = _majority_outcome(counts)
+
+            if outcome == PROPOSAL_STATUS_APPROVED:
+                if proposal.amount <= remaining_treasury:
+                    allocations[proposal.department] = allocations.get(proposal.department, 0.0) + proposal.amount
+                    remaining_treasury -= proposal.amount
+                    approved_proposal_ids.append(proposal.proposal_id)
+                else:
+                    outcome = PROPOSAL_STATUS_REJECTED_OVER_BUDGET
+                    rejected_proposal_ids.append(proposal.proposal_id)
+            else:
+                rejected_proposal_ids.append(proposal.proposal_id)
+
+            proposal_outcomes[proposal.proposal_id] = outcome
+
+        return ResolutionResult(
+            allocations=allocations,
+            approved_proposal_ids=approved_proposal_ids,
+            rejected_proposal_ids=rejected_proposal_ids,
+            proposal_outcomes=proposal_outcomes,
+            vote_counts=vote_counts,
+            remaining_treasury=remaining_treasury,
+            proposals=list(self.proposals),
+            votes=list(self.votes),
+            debate_messages=list(self.debate_messages),
+        )
+
+    def _proposal_by_id(self, proposal_id: str) -> Proposal | None:
+        return next((proposal for proposal in self.proposals if proposal.proposal_id == proposal_id), None)
+
+    def _vote_counts_for(self, proposal_id: str) -> dict[str, int]:
+        counts = {choice.value: 0 for choice in VoteChoice}
+        for vote in self.votes:
+            if vote.proposal_id == proposal_id:
+                counts[vote.vote.value] += 1
+        return counts
+
+
+def _majority_outcome(counts: Mapping[str, int]) -> str:
+    yes_votes = counts[VoteChoice.YES.value]
+    no_votes = counts[VoteChoice.NO.value]
+    non_abstaining_votes = yes_votes + no_votes
+
+    if non_abstaining_votes == 0:
+        return PROPOSAL_STATUS_REJECTED_ALL_ABSTAIN
+    if yes_votes == no_votes:
+        return PROPOSAL_STATUS_REJECTED_TIE
+    if yes_votes > non_abstaining_votes / 2:
+        return PROPOSAL_STATUS_APPROVED
+    return PROPOSAL_STATUS_REJECTED_MAJORITY
+
+
+def _validate_amount(amount: Any) -> float:
+    if isinstance(amount, bool):
+        raise ValueError("invalid_amount")
+    try:
+        amount_value = float(amount)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("invalid_amount") from exc
+    if amount_value < 0 or math.isnan(amount_value) or math.isinf(amount_value):
+        raise ValueError("invalid_amount")
+    return amount_value
+
+
+def _validate_vote(vote: Any) -> VoteChoice:
+    vote_value = _enum_value(vote)
+    try:
+        return VoteChoice(vote_value)
+    except ValueError as exc:
+        raise ValueError("invalid_vote") from exc
+
+
+def _action_to_mapping(action: Any) -> Mapping[str, Any]:
+    if hasattr(action, "to_dict"):
+        return action.to_dict()
+    if isinstance(action, Mapping):
+        return action
+    raise ValueError("invalid_action")
+
+
+def _enum_value(value: Any) -> str:
+    if isinstance(value, StrEnum):
+        return value.value
+    return str(value)

--- a/core/parliament.py
+++ b/core/parliament.py
@@ -54,6 +54,15 @@ class DebateMessage:
 
 
 @dataclass(frozen=True, slots=True)
+class ProposalAbstention:
+    """Explicit record that a minister skipped their proposal turn."""
+
+    agent_id: str
+    department: str
+    submitted_order: int = 0
+
+
+@dataclass(frozen=True, slots=True)
 class ResolutionResult:
     """Resolved parliamentary round output for the core game engine."""
 
@@ -66,6 +75,7 @@ class ResolutionResult:
     proposals: list[Proposal]
     votes: list[VoteRecord]
     debate_messages: list[DebateMessage]
+    proposal_abstentions: list[ProposalAbstention]
 
 
 @dataclass(slots=True)
@@ -78,13 +88,20 @@ class ParliamentRoundState:
     proposals: list[Proposal] = field(default_factory=list)
     votes: list[VoteRecord] = field(default_factory=list)
     debate_messages: list[DebateMessage] = field(default_factory=list)
+    proposal_abstentions: list[ProposalAbstention] = field(default_factory=list)
     _proposal_counter: int = 0
     _vote_counter: int = 0
     _debate_counter: int = 0
+    _abstention_counter: int = 0
     _proposing_agents: set[str] = field(default_factory=set)
+    _abstaining_agents: set[str] = field(default_factory=set)
     _votes_by_proposal_agent: set[tuple[str, str]] = field(default_factory=set)
 
-    def collect_action(self, phase: Phase, action: Any) -> Proposal | VoteRecord | DebateMessage | None:
+    def collect_action(
+        self,
+        phase: Phase,
+        action: Any,
+    ) -> Proposal | VoteRecord | DebateMessage | ProposalAbstention | None:
         """Collect one structured action if it belongs to the supplied phase."""
 
         data = _action_to_mapping(action)
@@ -101,6 +118,10 @@ class ParliamentRoundState:
                 department=str(data.get("department", "")),
                 amount=data.get("amount"),
                 justification=str(data.get("justification", "")),
+            )
+        if Phase(phase) == Phase.PROPOSAL and action_type == ActionType.ABSTAIN_FROM_PROPOSAL.value:
+            return self.submit_abstention(
+                agent_id=str(data.get("agent_id") or data.get("agent") or ""),
             )
         if Phase(phase) == Phase.VOTING and action_type == ActionType.VOTE.value:
             return self.submit_vote(
@@ -122,6 +143,25 @@ class ParliamentRoundState:
         self.debate_messages.append(debate_message)
         return debate_message
 
+    def submit_abstention(self, agent_id: str) -> ProposalAbstention:
+        """Record that an agent explicitly skipped their proposal turn."""
+
+        department = self.agent_departments.get(agent_id)
+        if department is None:
+            raise ValueError("unknown_agent")
+        if agent_id in self._proposing_agents or agent_id in self._abstaining_agents:
+            raise ValueError("duplicate_abstention")
+
+        self._abstention_counter += 1
+        abstention = ProposalAbstention(
+            agent_id=agent_id,
+            department=department,
+            submitted_order=self._abstention_counter,
+        )
+        self.proposal_abstentions.append(abstention)
+        self._abstaining_agents.add(agent_id)
+        return abstention
+
     def submit_proposal(
         self,
         agent_id: str,
@@ -131,7 +171,7 @@ class ParliamentRoundState:
     ) -> Proposal:
         """Validate and record a proposal for the agent's assigned department."""
 
-        if agent_id in self._proposing_agents:
+        if agent_id in self._proposing_agents or agent_id in self._abstaining_agents:
             raise ValueError("duplicate_proposal")
         if self.agent_departments.get(agent_id) != department:
             raise ValueError("wrong_department")
@@ -159,6 +199,8 @@ class ParliamentRoundState:
         proposal = self._proposal_by_id(proposal_id)
         if proposal is None:
             raise ValueError("proposal_not_found")
+        if agent_id not in self.agent_departments:
+            raise ValueError("unknown_agent")
         if agent_id == proposal.agent_id:
             raise ValueError("self_vote")
 
@@ -216,6 +258,7 @@ class ParliamentRoundState:
             proposals=list(self.proposals),
             votes=list(self.votes),
             debate_messages=list(self.debate_messages),
+            proposal_abstentions=list(self.proposal_abstentions),
         )
 
     def _proposal_by_id(self, proposal_id: str) -> Proposal | None:

--- a/tests/unit/test_parliament.py
+++ b/tests/unit/test_parliament.py
@@ -1,6 +1,8 @@
+import math
+
 import pytest
 
-from core.parliament import ParliamentRoundState, Proposal, VoteRecord
+from core.parliament import ParliamentRoundState, Proposal, ProposalAbstention, VoteRecord
 from schemas.actions import ActionType, VoteChoice
 from schemas.phases import Phase
 
@@ -57,6 +59,19 @@ def test_negative_amount_rejected():
             department="Social",
             amount=-1.0,
             justification="Negative budget",
+        )
+
+
+@pytest.mark.parametrize("amount", [math.nan, math.inf, -math.inf, True])
+def test_non_finite_and_bool_amounts_rejected(amount):
+    state = make_state()
+
+    with pytest.raises(ValueError, match="invalid_amount"):
+        state.submit_proposal(
+            agent_id="social-minister",
+            department="Social",
+            amount=amount,
+            justification="Invalid amount",
         )
 
 
@@ -129,6 +144,40 @@ def test_duplicate_vote_rejected():
         )
 
 
+def test_unknown_voter_rejected():
+    state = make_state()
+    proposal = state.submit_proposal(
+        agent_id="social-minister",
+        department="Social",
+        amount=10.0,
+        justification="Vote target",
+    )
+
+    with pytest.raises(ValueError, match="unknown_agent"):
+        state.submit_vote(
+            agent_id="unknown-minister",
+            proposal_id=proposal.proposal_id,
+            vote=VoteChoice.YES,
+        )
+
+
+def test_invalid_vote_value_rejected():
+    state = make_state()
+    proposal = state.submit_proposal(
+        agent_id="social-minister",
+        department="Social",
+        amount=10.0,
+        justification="Vote target",
+    )
+
+    with pytest.raises(ValueError, match="invalid_vote"):
+        state.submit_vote(
+            agent_id="health-minister",
+            proposal_id=proposal.proposal_id,
+            vote="MAYBE",
+        )
+
+
 def test_yes_majority_approves():
     state = make_state()
     proposal = state.submit_proposal(
@@ -164,6 +213,23 @@ def test_tie_rejects():
     assert result.proposal_outcomes[proposal.proposal_id] == "rejected_tie"
 
 
+def test_exact_fifty_percent_yes_boundary_rejects():
+    state = make_state()
+    proposal = state.submit_proposal(
+        agent_id="social-minister",
+        department="Social",
+        amount=10.0,
+        justification="Boundary target",
+    )
+    state.submit_vote("agriculture-minister", proposal.proposal_id, VoteChoice.YES)
+    state.submit_vote("health-minister", proposal.proposal_id, VoteChoice.NO)
+
+    result = state.resolve()
+
+    assert result.allocations["Social"] == 0.0
+    assert result.proposal_outcomes[proposal.proposal_id] == "rejected_tie"
+
+
 def test_all_abstain_rejects():
     state = make_state()
     proposal = state.submit_proposal(
@@ -174,6 +240,21 @@ def test_all_abstain_rejects():
     )
     state.submit_vote("agriculture-minister", proposal.proposal_id, VoteChoice.ABSTAIN)
     state.submit_vote("health-minister", proposal.proposal_id, VoteChoice.ABSTAIN)
+
+    result = state.resolve()
+
+    assert result.allocations["Social"] == 0.0
+    assert result.proposal_outcomes[proposal.proposal_id] == "rejected_all_abstain"
+
+
+def test_zero_vote_proposal_rejects_as_all_abstain():
+    state = make_state()
+    proposal = state.submit_proposal(
+        agent_id="social-minister",
+        department="Social",
+        amount=10.0,
+        justification="No vote target",
+    )
 
     result = state.resolve()
 
@@ -283,3 +364,17 @@ def test_collect_actions_over_phases_and_resolve_to_allocations():
     assert state.debate_messages[0].message == "Health can wait."
     assert isinstance(state.proposals[0], Proposal)
     assert isinstance(state.votes[0], VoteRecord)
+
+
+def test_collect_action_routes_abstain_from_proposal():
+    state = make_state()
+
+    abstention = state.collect_action(
+        Phase.PROPOSAL,
+        {"type": ActionType.ABSTAIN_FROM_PROPOSAL, "agent_id": "health-minister"},
+    )
+
+    assert isinstance(abstention, ProposalAbstention)
+    assert abstention.agent_id == "health-minister"
+    assert abstention.department == "Health"
+    assert state.proposal_abstentions == [abstention]

--- a/tests/unit/test_parliament.py
+++ b/tests/unit/test_parliament.py
@@ -1,0 +1,285 @@
+import pytest
+
+from core.parliament import ParliamentRoundState, Proposal, VoteRecord
+from schemas.actions import ActionType, VoteChoice
+from schemas.phases import Phase
+
+
+AGENT_DEPARTMENTS = {
+    "social-minister": "Social",
+    "agriculture-minister": "Agriculture",
+    "health-minister": "Health",
+}
+
+
+def make_state(treasury: float = 100.0) -> ParliamentRoundState:
+    return ParliamentRoundState(
+        round_number=1,
+        treasury_at_start=treasury,
+        agent_departments=AGENT_DEPARTMENTS,
+    )
+
+
+def test_valid_proposal_accepted():
+    state = make_state()
+
+    proposal = state.submit_proposal(
+        agent_id="social-minister",
+        department="Social",
+        amount=40.0,
+        justification="Keep essential services running",
+    )
+
+    assert proposal is not None
+    assert proposal.department == "Social"
+    assert proposal.amount == 40.0
+    assert state.proposals == [proposal]
+
+
+def test_wrong_department_rejected():
+    state = make_state()
+
+    with pytest.raises(ValueError, match="wrong_department"):
+        state.submit_proposal(
+            agent_id="social-minister",
+            department="Health",
+            amount=40.0,
+            justification="Invalid portfolio",
+        )
+
+
+def test_negative_amount_rejected():
+    state = make_state()
+
+    with pytest.raises(ValueError, match="invalid_amount"):
+        state.submit_proposal(
+            agent_id="social-minister",
+            department="Social",
+            amount=-1.0,
+            justification="Negative budget",
+        )
+
+
+def test_amount_over_treasury_rejected():
+    state = make_state(treasury=25.0)
+
+    with pytest.raises(ValueError, match="exceeds_treasury"):
+        state.submit_proposal(
+            agent_id="social-minister",
+            department="Social",
+            amount=30.0,
+            justification="Too expensive",
+        )
+
+
+def test_duplicate_proposal_rejected_after_first_valid_submission():
+    state = make_state()
+    state.submit_proposal(
+        agent_id="social-minister",
+        department="Social",
+        amount=10.0,
+        justification="First proposal",
+    )
+
+    with pytest.raises(ValueError, match="duplicate_proposal"):
+        state.submit_proposal(
+            agent_id="social-minister",
+            department="Social",
+            amount=20.0,
+            justification="Second proposal",
+        )
+
+
+def test_self_vote_rejected():
+    state = make_state()
+    proposal = state.submit_proposal(
+        agent_id="social-minister",
+        department="Social",
+        amount=10.0,
+        justification="Self vote target",
+    )
+
+    with pytest.raises(ValueError, match="self_vote"):
+        state.submit_vote(
+            agent_id="social-minister",
+            proposal_id=proposal.proposal_id,
+            vote=VoteChoice.YES,
+        )
+
+
+def test_duplicate_vote_rejected():
+    state = make_state()
+    proposal = state.submit_proposal(
+        agent_id="social-minister",
+        department="Social",
+        amount=10.0,
+        justification="Vote target",
+    )
+    state.submit_vote(
+        agent_id="health-minister",
+        proposal_id=proposal.proposal_id,
+        vote=VoteChoice.YES,
+    )
+
+    with pytest.raises(ValueError, match="duplicate_vote"):
+        state.submit_vote(
+            agent_id="health-minister",
+            proposal_id=proposal.proposal_id,
+            vote=VoteChoice.NO,
+        )
+
+
+def test_yes_majority_approves():
+    state = make_state()
+    proposal = state.submit_proposal(
+        agent_id="social-minister",
+        department="Social",
+        amount=10.0,
+        justification="Majority target",
+    )
+    state.submit_vote("agriculture-minister", proposal.proposal_id, VoteChoice.YES)
+    state.submit_vote("health-minister", proposal.proposal_id, VoteChoice.YES)
+
+    result = state.resolve()
+
+    assert result.allocations["Social"] == 10.0
+    assert result.approved_proposal_ids == [proposal.proposal_id]
+    assert result.proposal_outcomes[proposal.proposal_id] == "approved"
+
+
+def test_tie_rejects():
+    state = make_state()
+    proposal = state.submit_proposal(
+        agent_id="social-minister",
+        department="Social",
+        amount=10.0,
+        justification="Tie target",
+    )
+    state.submit_vote("agriculture-minister", proposal.proposal_id, VoteChoice.YES)
+    state.submit_vote("health-minister", proposal.proposal_id, VoteChoice.NO)
+
+    result = state.resolve()
+
+    assert result.allocations["Social"] == 0.0
+    assert result.proposal_outcomes[proposal.proposal_id] == "rejected_tie"
+
+
+def test_all_abstain_rejects():
+    state = make_state()
+    proposal = state.submit_proposal(
+        agent_id="social-minister",
+        department="Social",
+        amount=10.0,
+        justification="Abstain target",
+    )
+    state.submit_vote("agriculture-minister", proposal.proposal_id, VoteChoice.ABSTAIN)
+    state.submit_vote("health-minister", proposal.proposal_id, VoteChoice.ABSTAIN)
+
+    result = state.resolve()
+
+    assert result.allocations["Social"] == 0.0
+    assert result.proposal_outcomes[proposal.proposal_id] == "rejected_all_abstain"
+
+
+def test_abstentions_excluded_from_majority():
+    state = ParliamentRoundState(
+        round_number=1,
+        treasury_at_start=100.0,
+        agent_departments={
+            **AGENT_DEPARTMENTS,
+            "education-minister": "Education",
+        },
+    )
+    proposal = state.submit_proposal(
+        agent_id="social-minister",
+        department="Social",
+        amount=10.0,
+        justification="Abstention target",
+    )
+    state.submit_vote("agriculture-minister", proposal.proposal_id, VoteChoice.YES)
+    state.submit_vote("health-minister", proposal.proposal_id, VoteChoice.ABSTAIN)
+    state.submit_vote("education-minister", proposal.proposal_id, VoteChoice.ABSTAIN)
+
+    result = state.resolve()
+
+    assert result.allocations["Social"] == 10.0
+    assert result.vote_counts[proposal.proposal_id] == {"YES": 1, "NO": 0, "ABSTAIN": 2}
+
+
+def test_sequential_treasury_depletion_rejects_later_over_budget_proposal():
+    state = make_state(treasury=50.0)
+    first = state.submit_proposal(
+        agent_id="social-minister",
+        department="Social",
+        amount=40.0,
+        justification="First in order",
+    )
+    second = state.submit_proposal(
+        agent_id="health-minister",
+        department="Health",
+        amount=30.0,
+        justification="Later in order",
+    )
+
+    state.submit_vote("agriculture-minister", first.proposal_id, VoteChoice.YES)
+    state.submit_vote("health-minister", first.proposal_id, VoteChoice.YES)
+    state.submit_vote("social-minister", second.proposal_id, VoteChoice.YES)
+    state.submit_vote("agriculture-minister", second.proposal_id, VoteChoice.YES)
+
+    result = state.resolve()
+
+    assert result.allocations == {"Social": 40.0, "Agriculture": 0.0, "Health": 0.0}
+    assert result.proposal_outcomes[first.proposal_id] == "approved"
+    assert result.proposal_outcomes[second.proposal_id] == "rejected_exceeds_remaining_treasury"
+    assert result.remaining_treasury == 10.0
+
+
+def test_resolution_produces_allocation_dict_for_core_game():
+    state = make_state()
+    proposal = state.submit_proposal(
+        agent_id="social-minister",
+        department="Social",
+        amount=25.0,
+        justification="Core allocation",
+    )
+    state.submit_vote("agriculture-minister", proposal.proposal_id, VoteChoice.YES)
+    state.submit_vote("health-minister", proposal.proposal_id, VoteChoice.YES)
+
+    result = state.resolve()
+
+    assert isinstance(result.allocations, dict)
+    assert result.allocations == {"Social": 25.0, "Agriculture": 0.0, "Health": 0.0}
+
+
+def test_collect_actions_over_phases_and_resolve_to_allocations():
+    state = make_state()
+    state.collect_action(
+        Phase.DEBATE,
+        {"type": ActionType.DEBATE, "agent_id": "health-minister", "message": "Health can wait."},
+    )
+    state.collect_action(
+        Phase.PROPOSAL,
+        {
+            "type": ActionType.PROPOSE_BUDGET,
+            "agent_id": "social-minister",
+            "department": "Social",
+            "amount": 15,
+            "justification": "Public works",
+        },
+    )
+    proposal_id = state.proposals[0].proposal_id
+    state.collect_action(
+        Phase.VOTING,
+        {"type": ActionType.VOTE, "agent_id": "agriculture-minister", "proposal_id": proposal_id, "vote": "YES"},
+    )
+    state.collect_action(
+        Phase.VOTING,
+        {"type": ActionType.VOTE, "agent_id": "health-minister", "proposal_id": proposal_id, "vote": "YES"},
+    )
+
+    result = state.resolve()
+
+    assert result.allocations["Social"] == 15.0
+    assert state.debate_messages[0].message == "Health can wait."
+    assert isinstance(state.proposals[0], Proposal)
+    assert isinstance(state.votes[0], VoteRecord)


### PR DESCRIPTION
## Summary
- Add `core.parliament` as a focused adapter for collecting debate, proposal, and vote actions across parliamentary phases.
- Resolve public vote records into the `dict[str, float]` allocation mapping accepted by `NationGame.step(allocations)`.
- Cover proposal validation, vote validation, majority rules, abstentions, ties, and sequential treasury depletion with unit tests.

## Spec references
- `specification/03_TURN_STRUCTURE.md`: debate, proposal, voting, and budget execution phase ordering.
- `specification/05_VOTING_PROTOCOL.md`: public votes, self-vote prohibition, strict majority, abstention, tie, and treasury depletion rules.
- `specification/07_AGENT_ACTION_SPACE.md`: structured action types and validation constraints.
- `specification/08_OBSERVATION_SPACE.md`: public proposals, votes, and debate messages.
- `specification/11_GUARDRAILS.md`: no secret ballots, no debt, no private side-channel communication.
- `specification/13_RL_ADAPTERS_AND_TRAINING.md`: adapter-facing structured action contract and environment-side validation.

## Implementation details
- Introduces `Proposal`, `VoteRecord`, `DebateMessage`, `ParliamentRoundState`, and `ResolutionResult` dataclasses.
- `ParliamentRoundState.collect_action(...)` accepts phase-tagged structured actions and routes them to debate, proposal, or vote handlers.
- Proposal validation enforces own-department submissions, numeric non-negative amounts, initial treasury ceiling, and one valid proposal per agent per round.
- Vote validation enforces existing proposals, no duplicate votes, no self-votes, and `YES`/`NO`/`ABSTAIN` choices.
- Resolution excludes abstentions from majority math, rejects ties/all-abstain proposals, and processes approved proposals in submission order against remaining treasury.

## Test plan and command results
- `uv sync --extra dev` passed.
- `uv run pytest tests/unit/test_parliament.py` passed: 14 tests.
- `uv run pytest` passed: 125 tests.

## Out of scope
- Did not rewrite `core/game.py`.
- Did not implement an OpenEnv wrapper.
- Did not implement LLM prompts.
- Did not add telemetry persistence beyond returned resolution metadata.
- Left unrelated local files unstaged: `.cursor/`, `.sisyphus/...`, and `uv.lock`.

Made with [Cursor](https://cursor.com)