### PR TITLE
Harden OpenEnv wrapper contract tests

### DIFF
--- a/server/environment.py
+++ b/server/environment.py
@@ -5,6 +5,9 @@ from core.game import NationGame
 from server.models import NationState, NationAction, EventModel
 
 
+TREASURY_ALLOCATION_EPSILON = 1e-6
+
+
 class NationEnvironment(Env):
     """
     OpenEnv wrapper for the Nation Simulator core game engine.
@@ -53,9 +56,8 @@ class NationEnvironment(Env):
         exp_bids = np.exp(raw_bids_stable)
         percentages = exp_bids / np.sum(exp_bids)
 
-        # Retrieve the current treasury from the game's internal state
-        # Subtract a tiny epsilon to ensure floating point math during sum() doesn't exceed the balance
-        treasury = self.game.state["treasury"] - 1e-6
+        # Subtract a tiny epsilon so floating point allocation sums do not exceed the balance.
+        treasury = self.game.state()["treasury"] - TREASURY_ALLOCATION_EPSILON
 
         # Calculate exact dollar allocations, avoiding floating point overflow
         allocations_dict = {}

--- a/tests/integration/test_openenv_contract.py
+++ b/tests/integration/test_openenv_contract.py
@@ -1,0 +1,94 @@
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from server.environment import NationEnvironment
+from server.models import NationAction, NationState
+
+
+VALID_BID_COUNT = 6
+
+
+def make_equal_bid_action() -> NationAction:
+    return NationAction(bids=[0.0] * VALID_BID_COUNT)
+
+
+def assert_state_contract(state: NationState) -> None:
+    dumped_state = state.model_dump()
+
+    assert isinstance(state, NationState)
+    assert "treasury" in dumped_state
+    assert "population" in dumped_state
+    assert "productivity" in dumped_state
+    assert "active_events" in dumped_state
+
+
+def assert_state_is_serializable(state: NationState) -> None:
+    serialized = state.model_dump_json()
+
+    assert json.loads(serialized) == state.model_dump(mode="json")
+
+
+def test_reset_returns_state_and_info_dict():
+    env = NationEnvironment(seed=123)
+
+    state, info = env.reset()
+
+    assert_state_contract(state)
+    assert_state_is_serializable(state)
+    assert info == {}
+
+
+def test_step_returns_openenv_tuple_and_info_contract():
+    env = NationEnvironment(seed=123)
+    env.reset()
+
+    state, reward, terminated, truncated, info = env.step(make_equal_bid_action())
+
+    assert_state_contract(state)
+    assert_state_is_serializable(state)
+    assert isinstance(reward, float)
+    assert isinstance(terminated, bool)
+    assert isinstance(truncated, bool)
+    assert isinstance(info["reward_breakdown"], dict)
+    assert "termination_reason" in info
+
+
+def test_invalid_action_length_fails_validation():
+    with pytest.raises(ValidationError):
+        NationAction(bids=[0.0] * (VALID_BID_COUNT - 1))
+
+
+def test_one_random_valid_action_does_not_crash():
+    env = NationEnvironment(seed=123)
+    env.reset()
+    action = NationAction(bids=[0.15, -0.4, 1.2, 0.0, 2.4, -1.1])
+
+    state, reward, terminated, truncated, info = env.step(action)
+
+    assert_state_contract(state)
+    assert isinstance(reward, float)
+    assert isinstance(terminated, bool)
+    assert isinstance(truncated, bool)
+    assert isinstance(info["reward_breakdown"], dict)
+    assert "termination_reason" in info
+
+
+def test_repeated_stepping_eventually_terminates_or_reaches_max_rounds():
+    env = NationEnvironment(seed=123)
+    env.reset()
+    max_rounds = env.game.config.MAX_ROUNDS
+    terminated = False
+
+    for _ in range(max_rounds):
+        state, _, terminated, truncated, info = env.step(make_equal_bid_action())
+
+        assert_state_contract(state)
+        assert truncated is False
+        assert isinstance(info["reward_breakdown"], dict)
+        assert "termination_reason" in info
+        if terminated:
+            break
+
+    assert terminated or env.game.round >= max_rounds


### PR DESCRIPTION
## Summary
- Add OpenEnv wrapper contract coverage for `NationEnvironment.reset()` and `NationEnvironment.step()`.
- Cover serializable `NationState` observations, invalid `NationAction` bid length validation, random valid action execution, repeated stepping, and required `info` metadata.
- Fix wrapper treasury lookup to use the public `NationGame.state()` snapshot instead of indexing the method object.

## Spec References
- `specification/10_SUCCESS_CRITERIA.md`: episode termination conditions, max rounds, and termination reason expectations.
- `specification/13_RL_ADAPTERS_AND_TRAINING.md`: RL-facing environment contract, telemetry/reward fields, and adapter-facing validation expectations.
- `server/environment.py` and `server/models.py`: current continuous-bid OpenEnv wrapper contract from PR #6.

## Implementation Details
- Added `tests/integration/test_openenv_contract.py` for reset/step return shapes and metadata.
- Kept `NationEnvironment` as a continuous-bid wrapper and did not add parliamentary proposal/vote actions.
- Introduced a named epsilon constant for treasury allocation rounding and read treasury through `self.game.state()`.

## Test Plan and Results
- `uv sync --extra dev` completed successfully.
- `uv run pytest tests/integration/test_openenv_contract.py` initially failed on `self.game.state["treasury"]`; after the wrapper fix: `5 passed in 0.54s`.
- `uv run pytest`: `116 passed in 1.08s`.

## Out of Scope
- Parliamentary proposal/vote actions.
- LLM adapters.
- Training scripts.
- Benchmark expansion.
- Core game semantics changes.

Made with [Cursor](https://cursor.com)