### PR TITLE
feat: Option A — auto-fund critical, discretionary proposals, remove CRITICAL_FAILURE

### DIFF
--- a/PR_DESCRIPTION_OPTION_A.md
+++ b/PR_DESCRIPTION_OPTION_A.md
@@ -1,0 +1,63 @@
+# Option A: Auto-Fund Critical + Discretionary Proposals
+
+## Summary
+
+This PR implements **Option A** from `specification/proposed-amendments/01-critical-threshold-abstention-voting-fix.md`.
+
+**Mechanics:**
+
+- **Phase 5 — Step 0 (auto-critical):** Every department receives `Critical_d = Demand_d × 0.4` before discretionary execution. `sum(Critical_d)` is debited unconditionally. If `Treasury < sum(Critical_d)`, the episode ends with **BANKRUPTCY** (not `CRITICAL_FAILURE`).
+- **Phase 3:** Ministers propose **discretionary** amounts ≥ 0 (additional funding above auto-critical). `0` means “critical only.” **Proposal abstention is removed**; every minister must submit `PROPOSE_BUDGET`.
+- **Phase 5 — Step 1:** Approved discretionary is added on top of auto-critical. **Rejection** leaves the department at **critical-only** (not zero allocation).
+- **Revenue:** RF at exactly critical is **0** (zero revenue from that slice).
+- **Shutdown:** Consecutive rounds with **`sum(Discretionary_d) = 0`** (two rounds), not zero total allocation.
+- **Termination:** `CRITICAL_FAILURE` is removed. Remaining reasons: **BANKRUPTCY**, **SHUTDOWN**, **MAX_ROUNDS**, **PROSPERITY_THRESHOLD**.
+- **Rewards:** No “critical failure” penalty in `compute_reward`. Bankruptcy still applies `BANKRUPTCY_PENALTY` via the `critical_penalty` field on the step breakdown (existing implementation pattern).
+
+**Direct-allocation shortcut:** Still interprets the mapping as desired **total** per department; the engine applies auto-critical first, then discretionary from the remainder. **`StepResult.observation` now snapshots end-of-round state** before the next round’s `_start_round()` resets sector rows (fixes stale allocation in observations).
+
+## Branch note
+
+In this Cursor worktree, Git refused `feature/option-a-critical-auto-fund` because that branch is already checked out in another worktree. This commit is on **`feature/option-a-critical-auto-fund-8fmz`** (or the current HEAD branch at merge time). Rename or cherry-pick onto `feature/option-a-critical-auto-fund` as needed.
+
+## Files changed
+
+| Path | Change |
+|------|--------|
+| `core/game.py` | Remove `CRITICAL_FAILURE` / critical invariant path; simplify `_finish_round`; `compute_reward` call without critical penalty; direct allocation returns observation snapshot before next `_start_round`; `_result` accepts optional `observation`. |
+| `core/reward.py` | Remove critical-failure penalty parameters and logic; document bankruptcy override on `RewardBreakdown.critical_penalty`. |
+| `core/parliament.py` | Remove `ProposalAbstention`, `submit_abstention`, and `proposal_abstentions` from resolution state. |
+| `core/__init__.py` | Drop `ProposalAbstention` export. |
+| `server/models.py` | Remove `ABSTAIN_FROM_PROPOSAL` from `ParliamentaryAction.to_engine_dict`; doc discretionary proposals. |
+| `scripts/deep_audit_run.py` | Root-cause printout for **BANKRUPTCY** instead of removed `CRITICAL_FAILURE`. |
+| `specification/02_GAME_RULES_REFERENCE.md` | Must propose; auto-critical; discretionary; shutdown on zero discretionary; bankruptcy for unaffordable critical. |
+| `specification/03_TURN_STRUCTURE.md` | Phase 5 Step 0/1; Phase 3 mandatory proposals; shutdown counter on discretionary; remove critical-failure phase text. |
+| `specification/04_ECONOMY_MODEL.md` | Mandatory vs discretionary; RF=0 at critical; remove `CRITICAL_FAILURE` termination; align tables. |
+| `specification/05_VOTING_PROTOCOL.md` | Rejection = critical-only; no proposal abstention. |
+| `specification/07_AGENT_ACTION_SPACE.md` | Remove `ABSTAIN_FROM_PROPOSAL`; Phase 3 = `PROPOSE_BUDGET` only. |
+| `specification/09_REWARD_MODEL.md` | Remove critical-failure penalty; bankruptcy adjustment; update examples/tables. |
+| `specification/10_SUCCESS_CRITERIA.md` | Remove critical failure; shutdown discretionary; termination list. |
+| `tests/fixtures/reward_scenarios.py` | Below-critical economy fixture: expect **no** -1000 reward penalty. |
+| `tests/integration/test_game_loop.py` | Option A scenarios: auto-critical, zero discretionary, shutdown loop, bankruptcy, direct allocation observation, rejection = critical. |
+| `tests/unit/test_action_schema.py` | Assert proposal phase excludes `ABSTAIN_FROM_PROPOSAL`. |
+| `tests/unit/test_parliament.py` | Remove unused `ProposalAbstention` import. |
+| `tests/unit/test_reward.py` | Remove critical-failure penalty test; assert default `critical_penalty` zero from `compute_reward`. |
+| `tests/unit/test_reward_fixtures.py` | Align with reward changes; rename scenario assertion. |
+| `PR_DESCRIPTION_OPTION_A.md` | This file. |
+
+## Migration / API notes
+
+- **`ABSTAIN_FROM_PROPOSAL` removed** from the OpenEnv `ParliamentaryAction` mapping. External agents and tools must use **`PROPOSE_BUDGET` with `amount: 0`** instead of abstaining.
+- **`ProposalAbstention` removed** from `core.parliament` and package exports. Callers should only use `submit_proposal`.
+- **Termination string `CRITICAL_FAILURE`** is no longer produced by `NationGame`. Metrics or dashboards keyed on it should use **BANKRUPTCY** / **SHUTDOWN** / etc.
+- **`compute_reward`** no longer accepts `critical_failed` / `critical_failure_occurred` / `critical_penalty_val`.
+
+## Test plan
+
+- `uv sync --extra dev`
+- `uv run pytest` (full suite; all tests green in this worktree)
+
+## Intentionally not changed
+
+- `core/revenue.py` (per amendment).
+- `training/` (per user request; separate amendment).

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -20,7 +20,6 @@ from .parliament import (
     DebateMessage,
     ParliamentRoundState,
     Proposal,
-    ProposalAbstention,
     ResolutionResult,
     VoteRecord,
 )
@@ -36,7 +35,6 @@ __all__ = [
     "StepResult",
     "ParliamentRoundState",
     "Proposal",
-    "ProposalAbstention",
     "VoteRecord",
     "DebateMessage",
     "ResolutionResult",

--- a/core/game.py
+++ b/core/game.py
@@ -25,7 +25,6 @@ PROPOSAL_STATUS_PENDING = "pending"
 PROPOSAL_STATUS_APPROVED = "approved"
 PROPOSAL_STATUS_REJECTED = "rejected"
 PROPOSAL_STATUS_REJECTED_INVALID = "rejected_invalid"
-TERMINATION_CRITICAL_FAILURE = "CRITICAL_FAILURE"
 TERMINATION_BANKRUPTCY = "BANKRUPTCY"
 TERMINATION_SHUTDOWN = "SHUTDOWN"
 TERMINATION_MAX_ROUNDS = "MAX_ROUNDS"
@@ -416,9 +415,6 @@ class NationGame:
             if budget_status == "bankruptcy":
                 self._finish_round(budget_bankruptcy=True, terminate_immediately=True)
                 info["termination_reason"] = self.termination_reason
-            elif budget_status == "critical_invariant":
-                self._finish_round(critical_failed=True, terminate_immediately=True)
-                info["termination_reason"] = self.termination_reason
         elif self.phase == Phase.CONSUMPTION_AND_EVENT_IMPACT and not self.done:
             self._compute_consumption()
         elif self.phase == Phase.REVENUE_CALCULATION and not self.done:
@@ -428,7 +424,7 @@ class NationGame:
             self.treasury.credit(self.last_total_surplus)
             self.treasury.apply_baseline_tax()
         elif self.phase == Phase.TERMINATION_CHECK and not self.done:
-            self._finish_round(critical_failed=False)
+            self._finish_round()
             info["termination_reason"] = self.termination_reason
 
     def _run_direct_allocation_round(self, allocations: Mapping[str, Any]) -> StepResult:
@@ -488,7 +484,7 @@ class NationGame:
         self.treasury.credit(self.last_total_surplus)
         self.treasury.apply_baseline_tax()
 
-        self._finish_round(critical_failed=False, completed_round=self.round)
+        self._finish_round(completed_round=self.round)
         info = {
             "accepted_actions": [{"type": "DIRECT_ALLOCATION"}],
             "ignored_actions": [],
@@ -496,11 +492,13 @@ class NationGame:
             "termination_reason": self.termination_reason,
         }
         self.last_info = info
+        completed_round_num = self.round
+        end_observation = self.state()
         if not self.done:
             self.round += 1
             self.phase = Phase.EVENT_REVELATION
             self._start_round()
-        return self._result(info, completed_round=self.round - 1 if not self.done else self.round)
+        return self._result(info, completed_round=completed_round_num, observation=end_observation)
 
     def _total_critical_funding(self) -> float:
         """Total critical minimum spend for all sectors this round (population-based)."""
@@ -534,10 +532,6 @@ class NationGame:
 
         self.last_total_discretionary = disc_debited
         self.last_total_allocation = total_c + disc_debited
-        if any(
-            sector.is_critical_failure(self.population.value) for sector in self.sectors.values()
-        ):
-            return "critical_invariant"
         return "ok"
 
     def _tally_votes(self) -> None:
@@ -572,21 +566,17 @@ class NationGame:
     def _finish_round(
         self,
         *,
-        critical_failed: bool = False,
         budget_bankruptcy: bool = False,
         terminate_immediately: bool = False,
         completed_round: int | None = None,
     ) -> None:
         completed_round = completed_round or self.round
-        hard_failure = critical_failed or budget_bankruptcy
-        if budget_bankruptcy or critical_failed:
+        hard_failure = budget_bankruptcy
+        if budget_bankruptcy:
             self.last_total_revenue = 0.0
             self.last_total_surplus = 0.0
             self.done = True
-            if budget_bankruptcy:
-                self.termination_reason = TERMINATION_BANKRUPTCY
-            else:
-                self.termination_reason = TERMINATION_CRITICAL_FAILURE
+            self.termination_reason = TERMINATION_BANKRUPTCY
         else:
             revenue_factors = [sector.revenue_factor_value for sector in self.sectors.values()]
             self.productivity.update(revenue_factors)
@@ -606,13 +596,11 @@ class NationGame:
             population=self.population.value,
             productivity=self.productivity.value,
             round_num=completed_round,
-            critical_failed=hard_failure,
             **zone_penalty_overrides,
             productivity_bonus_scale=self.config.PRODUCTIVITY_BONUS_SCALE,
             survival_bonus_per_round=self.config.SURVIVAL_BONUS_PER_ROUND,
             over_alloc_penalty_val=self.config.OVER_ALLOC_PENALTY,
             under_alloc_penalty_val=self.config.UNDER_ALLOC_PENALTY,
-            critical_penalty_val=self.config.CRITICAL_PENALTY,
         )
         if self.termination_reason == TERMINATION_BANKRUPTCY:
             self.last_reward.critical_penalty = self.config.BANKRUPTCY_PENALTY
@@ -770,8 +758,14 @@ class NationGame:
     def _proposal_by_id(self, proposal_id: str) -> Proposal | None:
         return next((proposal for proposal in self.proposals if proposal.proposal_id == proposal_id), None)
 
-    def _result(self, info: dict[str, Any], completed_round: int | None = None) -> StepResult:
-        observation = self.state()
+    def _result(
+        self,
+        info: dict[str, Any],
+        completed_round: int | None = None,
+        *,
+        observation: dict[str, Any] | None = None,
+    ) -> StepResult:
+        observation = dict(observation) if observation is not None else self.state()
         if completed_round is not None:
             year, quarter = self._year_quarter(completed_round)
             observation["round"] = completed_round

--- a/core/parliament.py
+++ b/core/parliament.py
@@ -54,15 +54,6 @@ class DebateMessage:
 
 
 @dataclass(frozen=True, slots=True)
-class ProposalAbstention:
-    """Explicit record that a minister skipped their proposal turn."""
-
-    agent_id: str
-    department: str
-    submitted_order: int = 0
-
-
-@dataclass(frozen=True, slots=True)
 class ResolutionResult:
     """Resolved parliamentary round output for the core game engine."""
 
@@ -75,7 +66,6 @@ class ResolutionResult:
     proposals: list[Proposal]
     votes: list[VoteRecord]
     debate_messages: list[DebateMessage]
-    proposal_abstentions: list[ProposalAbstention]
 
 
 @dataclass(slots=True)
@@ -88,20 +78,17 @@ class ParliamentRoundState:
     proposals: list[Proposal] = field(default_factory=list)
     votes: list[VoteRecord] = field(default_factory=list)
     debate_messages: list[DebateMessage] = field(default_factory=list)
-    proposal_abstentions: list[ProposalAbstention] = field(default_factory=list)
     _proposal_counter: int = 0
     _vote_counter: int = 0
     _debate_counter: int = 0
-    _abstention_counter: int = 0
     _proposing_agents: set[str] = field(default_factory=set)
-    _abstaining_agents: set[str] = field(default_factory=set)
     _votes_by_proposal_agent: set[tuple[str, str]] = field(default_factory=set)
 
     def collect_action(
         self,
         phase: Phase,
         action: Any,
-    ) -> Proposal | VoteRecord | DebateMessage | ProposalAbstention | None:
+    ) -> Proposal | VoteRecord | DebateMessage | None:
         """Collect one structured action if it belongs to the supplied phase."""
 
         data = _action_to_mapping(action)
@@ -139,25 +126,6 @@ class ParliamentRoundState:
         self.debate_messages.append(debate_message)
         return debate_message
 
-    def submit_abstention(self, agent_id: str) -> ProposalAbstention:
-        """Record that an agent explicitly skipped their proposal turn."""
-
-        department = self.agent_departments.get(agent_id)
-        if department is None:
-            raise ValueError("unknown_agent")
-        if agent_id in self._proposing_agents or agent_id in self._abstaining_agents:
-            raise ValueError("duplicate_abstention")
-
-        self._abstention_counter += 1
-        abstention = ProposalAbstention(
-            agent_id=agent_id,
-            department=department,
-            submitted_order=self._abstention_counter,
-        )
-        self.proposal_abstentions.append(abstention)
-        self._abstaining_agents.add(agent_id)
-        return abstention
-
     def submit_proposal(
         self,
         agent_id: str,
@@ -167,7 +135,7 @@ class ParliamentRoundState:
     ) -> Proposal:
         """Validate and record a proposal for the agent's assigned department."""
 
-        if agent_id in self._proposing_agents or agent_id in self._abstaining_agents:
+        if agent_id in self._proposing_agents:
             raise ValueError("duplicate_proposal")
         if self.agent_departments.get(agent_id) != department:
             raise ValueError("wrong_department")
@@ -254,7 +222,6 @@ class ParliamentRoundState:
             proposals=list(self.proposals),
             votes=list(self.votes),
             debate_messages=list(self.debate_messages),
-            proposal_abstentions=list(self.proposal_abstentions),
         )
 
     def _proposal_by_id(self, proposal_id: str) -> Proposal | None:

--- a/core/reward.py
+++ b/core/reward.py
@@ -1,14 +1,19 @@
 """
 reward.py — Per-step reward calculator.
 
-Implements the full reward formula from spec 09:
+Implements the reward formula from spec 09 (Option A):
 
   R_t = Base_Reward
       + Productivity_Bonus
       + Survival_Bonus
       + Over_Allocation_Penalty
       + Under_Allocation_Penalty
-      - Critical_Penalty
+
+The ``critical_penalty`` field on :class:`RewardBreakdown` is reserved for
+episode-ending financial failure: :class:`core.game.NationGame` may set it to
+``BANKRUPTCY_PENALTY`` when the treasury cannot cover mandatory critical funding.
+There is no separate reward penalty for "critical failure" termination — that
+outcome was removed under auto-funded critical (Option A).
 """
 
 from __future__ import annotations
@@ -31,7 +36,7 @@ class RewardBreakdown:
     survival_bonus: float       # +10 × round_num
     over_alloc_penalty: float   # -5 × count(sectors in wastage zone)
     under_alloc_penalty: float  # -10 × count(sectors between critical and demand)
-    critical_penalty: float     # -1000 if any sector below critical
+    critical_penalty: float     # set by NationGame on bankruptcy only (default 0)
 
     @property
     def over_allocation_penalty(self) -> float:
@@ -51,7 +56,7 @@ class RewardBreakdown:
             + self.survival_bonus
             + self.over_alloc_penalty
             + self.under_alloc_penalty
-            + self.critical_penalty  # already negative
+            + self.critical_penalty  # bankruptcy override when set
         )
 
     def to_dict(self) -> dict:
@@ -72,18 +77,15 @@ def compute_reward(
     population: int | None = None,
     productivity: float = INITIAL_PRODUCTIVITY,
     round_num: int | None = None,
-    critical_failed: bool | None = None,
     *,
     prosperity: float | None = None,
     rounds_survived: int | None = None,
     over_allocated_count: int | None = None,
     under_allocated_count: int | None = None,
-    critical_failure_occurred: bool | None = None,
     productivity_bonus_scale: float = 50.0,
     survival_bonus_per_round: float = 10.0,
     over_alloc_penalty_val: float = -5.0,
     under_alloc_penalty_val: float = -10.0,
-    critical_penalty_val: float = -1000.0,
 ) -> RewardBreakdown:
     """
     Compute the per-step reward.
@@ -100,8 +102,6 @@ def compute_reward(
         Current national productivity.
     round_num : int
         Current round number (1-indexed).
-    critical_failed : bool
-        True if any sector fell below critical this round.
 
     Returns
     -------
@@ -137,18 +137,13 @@ def compute_reward(
     over_penalty = over_alloc_penalty_val * over_count
     under_penalty = under_alloc_penalty_val * under_count
 
-    # Critical penalty
-    if critical_failure_occurred is not None:
-        critical_failed = critical_failure_occurred
-    crit_penalty = critical_penalty_val if critical_failed else 0.0
-
     return RewardBreakdown(
         base_reward=base_reward,
         productivity_bonus=prod_bonus,
         survival_bonus=survival,
         over_alloc_penalty=over_penalty,
         under_alloc_penalty=under_penalty,
-        critical_penalty=crit_penalty,
+        critical_penalty=0.0,
     )
 
 

--- a/scripts/deep_audit_run.py
+++ b/scripts/deep_audit_run.py
@@ -71,15 +71,21 @@ def run_labeled_trial(rounds=10):
             print("---------------------------\n", flush=True)
 
         if done:
-            if info.get("termination_reason") == "CRITICAL_FAILURE":
-                print("ROOT CAUSE ANALYSIS:")
+            if info.get("termination_reason") == "BANKRUPTCY":
+                print("ROOT CAUSE ANALYSIS (treasury could not cover mandatory spend):")
                 for name, sector in env.game.sectors.items():
                     crit_val = sector.critical(obs.population)
                     demand_val = float(sector.demand)
                     if sector.allocation < crit_val:
-                        print(f"  [!] Sector '{name}' COLLAPSED: Allocation ${sector.allocation:.2f} < Critical ${crit_val:.2f}")
+                        print(
+                            f"  [!] Sector '{name}' below critical: "
+                            f"Allocation ${sector.allocation:.2f} < Critical ${crit_val:.2f}"
+                        )
                     elif sector.allocation < demand_val:
-                        print(f"  [-] Sector '{name}' under-funded: Allocation ${sector.allocation:.2f} < Demand ${demand_val:.2f}")
+                        print(
+                            f"  [-] Sector '{name}' under-funded: "
+                            f"Allocation ${sector.allocation:.2f} < Demand ${demand_val:.2f}"
+                        )
             print(f"\nSIMULATION ENDED. Reason: {info.get('termination_reason')}")
             break
 

--- a/server/models.py
+++ b/server/models.py
@@ -68,6 +68,9 @@ class ParliamentaryAction(Action):
       - FINISH_DEBATE:          requires `reason`
       - PROPOSE_BUDGET:         requires `department`, `amount`, `justification`
       - VOTE:                   requires `proposal_id`, `vote`
+
+    ``amount`` in PROPOSE_BUDGET is discretionary funding above the auto-funded
+    critical floor (see Option A in game rules).
     """
 
     agent_id: str
@@ -100,8 +103,6 @@ class ParliamentaryAction(Action):
         elif self.type == "VOTE":
             d["proposal_id"] = self.proposal_id or ""
             d["vote"] = str(self.vote) if self.vote else "ABSTAIN"
-        elif self.type == "ABSTAIN_FROM_PROPOSAL":
-            d["department"] = self.department or self.agent_id
         return d
 
 

--- a/specification/02_GAME_RULES_REFERENCE.md
+++ b/specification/02_GAME_RULES_REFERENCE.md
@@ -11,8 +11,8 @@ Single-page anchor document defining all game mechanics using MUST/MUST NOT/MAY 
 - Each minister MUST represent one department in the parliamentary simulation
 - Ministers MUST act autonomously based on their assigned portfolio interests
 - No minister MAY represent more than one department simultaneously
-- A minister MAY abstain from proposing a budget for their own department in any round
-- A minister MAY abstain from voting on any proposal, including their own
+- Each minister MUST submit exactly one budget proposal every round during Phase 3 (amount MAY be zero)
+- A minister MAY abstain from voting on any proposal (voting abstention remains distinct from proposal abstention, which is removed)
 
 ---
 
@@ -29,8 +29,9 @@ Single-page anchor document defining all game mechanics using MUST/MUST NOT/MAY 
 
 ## Budget Proposals
 
-- Each minister MUST be able to propose a budget allocation for their own department
-- A budget proposal MUST specify an exact amount requested from the treasury
+- Each minister MUST propose every round during Phase 3; there is no abstention from proposing
+- A budget proposal MUST specify a **discretionary** amount (≥ 0): additional funding requested **above** the department’s auto-funded critical floor `Critical_d = Demand_d × 0.4`
+- A proposal of **0** means the minister accepts only the automatic critical funding for that round (no extra discretionary spend)
 - Proposals MUST be submitted sequentially during the proposal phase
 - Proposals follow a rotating order that shifts each round (round-robin rotation)
 - The starting department for round t is determined by `departments[t mod N]` where N is the number of departments
@@ -38,8 +39,8 @@ Single-page anchor document defining all game mechanics using MUST/MUST NOT/MAY 
 - Round 2 order: Agriculture → Health → Education → Defense → Commerce → Social
 - Round 3 order: Health → Education → Defense → Commerce → Social → Agriculture
 - This rotation prevents any department from having a permanent first-mover advantage
-- A minister MAY propose zero (0) as their budget request
-- A minister MAY propose any amount up to and including the current treasury balance
+- A minister MAY propose zero (0) discretionary (auto-critical still applies in Phase 5)
+- A minister MAY propose any **discretionary** amount up to the treasury **discretionary headroom**: `Treasury_balance - sum(Critical_d)` at submission time (validation uses remaining balance after reserving mandatory critical)
 - A proposal MUST be publicly announced before voting begins
 - No minister MAY propose a budget after the proposal phase has ended
 
@@ -91,17 +92,19 @@ Single-page anchor document defining all game mechanics using MUST/MUST NOT/MAY 
 - Over-consumption (`Consumption > Allocation`) is IMPOSSIBLE by design: `Consumption = min(Allocation, Demand_d)`
 - Under-funding (`Allocation < Demand_d`) causes reduced revenue but NOT bankruptcy
 
-## Critical Threshold
+## Critical threshold & auto-critical funding (Option A)
 
-- Each sector has a critical threshold = 40% of its demand
-- If allocated budget is below this threshold: CRITICAL FAILURE, episode ends immediately
-- Critical represents the minimum funding needed to prevent sector collapse
-- Critical threshold is checked after budget allocation (Phase 5)
+- Each sector has a critical threshold `Critical_d = Demand_d × 0.4` (minimum viable operational floor)
+- **Auto-critical (Phase 5, Step 0)**: Before any voted discretionary amounts are applied, every department receives `Critical_d` from the treasury unconditionally; that sum is debited first
+- If `Treasury < sum(Critical_d)` at budget execution, the episode ends with **BANKRUPTCY** (not a separate “critical failure” termination)
+- At allocation exactly equal to `Critical_d`, revenue factor is **0** (zero revenue from that department that round); auto-critical is treated as pure survival cost
+- **Discretionary (Phase 3 proposals)**: Approved discretionary amounts are added on top of auto-critical; total allocation = `Critical_d + Discretionary_d`
+- There is **no** episode termination solely because allocation is below critical—execution guarantees at least critical for every department whenever the treasury can afford it
 
 ## Shutdown
 
-- The episode MUST end immediately if `sum(Allocation_d) = 0` for 2 consecutive rounds
-- Shutdown represents governance collapse where parliament cannot agree on any budget
+- The episode MUST end if `sum(Discretionary_d) = 0` for **2 consecutive rounds** (all approved discretionary amounts are zero). Because auto-critical is always funded when solvent, total allocation is not zero; shutdown tracks **discretionary** stagnation only
+- Shutdown represents governance collapse where parliament approves no growth investment above survival baselines
 - Shutdown is DISTINCT from bankruptcy: treasury may still be positive
 - Shutdown does NOT trigger the -1000 bankruptcy penalty
 - Shutdown condition is checked during Phase 9 (Termination Check)
@@ -125,4 +128,4 @@ Single-page anchor document defining all game mechanics using MUST/MUST NOT/MAY 
 
 ## Example
 
-- **Example**: Minister of Health proposes 300 units for healthcare. Treasury currently holds 1000 units. The proposal is debated, voted on, and receives 3 YES votes, 1 NO vote, and 2 ABSTAIN votes from 6 ministers. Since 3 YES > 1 NO (majority of 4 non-abstaining votes), the proposal is approved. Treasury is reduced to 700 units. Health's demand is 250 units (baseline 90 adjusted for population and events). Since allocation (300) exceeds demand, Health consumes 250 and the 50 units unspent return to treasury. Revenue factor at this allocation level (120% of demand) is 1.16, so Health generates 300 × 1.16 × Productivity in revenue.
+- **Example**: Minister of Health proposes **20 discretionary** units (on top of auto-critical). Treasury holds 1000 units; total critical across departments is 190, so discretionary headroom is 810. The proposal is debated, voted on, and receives 3 YES votes, 1 NO vote, and 2 ABSTAIN votes from 6 ministers. Since 3 YES > 1 NO (majority of 4 non-abstaining votes), the proposal is approved. In Phase 5, auto-critical is funded first; then Health receives **critical + 20** total. Treasury is debited `sum(Critical_d)` plus approved discretionary. Revenue is computed on **total** allocation (critical + discretionary).

--- a/specification/03_TURN_STRUCTURE.md
+++ b/specification/03_TURN_STRUCTURE.md
@@ -57,7 +57,7 @@
 
 ## Phase 3: Budget Proposal Phase
 
-**Purpose**: Each minister proposes a budget allocation for their department.
+**Purpose**: Each minister proposes **discretionary** additional funding for their department (above the auto-funded critical floor).
 
 **Execution Order**:
 - Ministers propose in rotating order (round-robin), not random order
@@ -67,14 +67,14 @@
 - Round 2: Agriculture → Health → Education → Defense → Commerce → Social
 - Round 3: Health → Education → Defense → Commerce → Social → Agriculture
 - This rotation shifts each round, preventing any department from having permanent first-mover advantage
-- Each minister submits:
+- Each minister MUST submit exactly one proposal:
   - Department identifier
-  - Requested budget amount (must be within valid range)
+  - **Discretionary** amount ≥ 0 (extra funding requested above `Critical_d`; **0** means “critical only”)
 - Proposals are public (all ministers see each proposal as it occurs)
-- A minister MAY abstain from proposing (skip their turn)
+- **Abstention from proposing is removed** — every minister must actively submit (including `amount: 0`)
 - Treasury remains unchanged until Phase 5
 
-**Treasury Note**: Treasury is NOT debited during this phase. Proposals are promises only.
+**Treasury Note**: Treasury is NOT debited during this phase. Proposals are promises only. Valid discretionary amounts are capped by discretionary headroom (`Treasury - sum(Critical_d)`), not raw treasury alone.
 
 ## Phase 4: Voting Phase
 
@@ -94,26 +94,26 @@
 
 ## Phase 5: Budget Execution Phase
 
-**Purpose**: Approved budgets are debited from treasury. Critical threshold is checked.
+**Purpose**: Apply **auto-critical** funding for all departments, then execute **approved discretionary** proposals on top. Debiting follows mandatory-first, then discretionary.
 
-**Critical Threshold Check** (executed before budget execution):
-- For each department: if `Allocation_d < Critical_d` → **CRITICAL FAILURE**, episode ends
-- Critical threshold formula: `Critical_d = Demand_d × 0.4`
-- This check happens BEFORE treasury is debited
-- If any department fails the critical threshold, the episode terminates immediately with status CRITICAL_FAILURE
+**Step 0 — Auto-fund critical (mandatory)**:
+- For each department: set baseline allocation to `Critical_d = Demand_d × 0.4`
+- Debit `sum(Critical_d)` from treasury unconditionally
+- If `Treasury < sum(Critical_d)` **before** this debit: episode ends with **BANKRUPTCY** (Phase 5 immediate termination path)
+- Revenue factor at exactly `Critical_d` is **0** (no revenue from that department this round from the critical slice)
+
+**Step 1 — Approved discretionary**:
+- For each proposal with status APPROVED: add `Discretionary_d` (the proposed amount) to that department’s allocation
+- Debit the treasury for each approved discretionary amount (sequential depletion: later approvals see reduced remaining balance during vote tally / ordering)
+- **Rejected** proposals: department keeps **only** auto-critical (`Allocation_d = Critical_d`); no discretionary debit for that department
+- Total allocation: `Allocation_d = Critical_d + Discretionary_d` (with `Discretionary_d = 0` if rejected or if proposal amount was 0)
 
 **Execution Order**:
-1. Check critical threshold for all departments
-2. If any check fails: episode ends
-3. For each approved proposal:
-   - Treasury is debited by the approved amount
-   - Department receives allocated budget
-4. Rejected proposals: no treasury change
-5. Abstained proposals (if minister abstained from proposing): treated as rejected
+1. Auto-fund critical for all departments (or BANKRUPTCY if unaffordable)
+2. Apply approved discretionary on top; handle rejections as “critical only”
+3. Proceed to Phase 6 with final allocations
 
-**Treasury Note**: Treasury is debited at this point. The total debited is `sum(Allocation_d)` across all approved proposals. If treasury would go negative after critical check passes, bankruptcy is triggered (see Termination Check Phase).
-
-**Critical Failure Rationale**: A department receiving less than 40% of its demand cannot fulfill basic functions. This is an immediate failure condition, not a gradual degradation.
+**Treasury Note**: Total Phase 5 debit = `sum(Critical_d) + sum(approved Discretionary_d)`. There is **no** separate `CRITICAL_FAILURE` termination; unaffordable mandatory critical is **BANKRUPTCY**.
 
 ## Phase 6: Consumption & Event Impact Phase
 
@@ -140,10 +140,11 @@
 - Departments in deficit generate reduced revenue based on shortfall
 - Treasury is credited IMMEDIATELY with `sum(Department_Revenue_d)`
 
-**Treasury Formula**:
+**Treasury Formula** (same-round, after Phase 5 debits):
 ```
 Treasury_after_Revenue = Treasury_before_Phase5 - sum(Allocation_d) + sum(Department_Revenue_d)
 ```
+where `sum(Allocation_d)` includes both auto-critical and discretionary components.
 
 **Key Point**: Revenue applies in the SAME ROUND it is generated. There is no "next round" delay.
 
@@ -176,27 +177,27 @@ Treasury_after_Revenue = Treasury_before_Phase5 - sum(Allocation_d) + sum(Depart
 - Update population: `Population_t = Population_{t-1} × (1 + Birth_Rate - Death_Rate)`
   - Birth_Rate and Death_Rate depend on department performance and events
 
-**Shutdown Counter**: A counter tracks consecutive rounds with zero total allocation.
-- Shutdown counter increments when `sum(Allocation_d) = 0`
-- Shutdown counter resets to 0 when `sum(Allocation_d) > 0`
+**Shutdown Counter**: A counter tracks consecutive rounds with **zero total discretionary** approved spend.
+- Shutdown counter increments when `sum(Discretionary_d) = 0` (all departments’ approved discretionary amounts are 0)
+- Shutdown counter resets to 0 when `sum(Discretionary_d) > 0`
 - If Shutdown counter >= 2, episode terminates with status SHUTDOWN
+- Note: Auto-critical is always positive when solvent, so `sum(Allocation_d) = 0` is not used for shutdown under Option A
 
 **Execution Order**:
 1. Update time display
 2. Update productivity and population
 3. Check shutdown condition: if Shutdown counter >= 2, episode ends (governance collapse)
 4. Check bankruptcy condition: if treasury <= 0, episode ends (failure)
-5. Check critical failure condition: already handled in Phase 5, included here for completeness
-6. Check max rounds condition: if round >= max_rounds, episode ends (evaluate success)
-7. Check prosperity threshold: if prosperity >= target, episode ends (success)
-8. If any termination condition is met:
+5. Check max rounds condition: if round >= max_rounds, episode ends (evaluate success)
+6. Check prosperity threshold: if prosperity >= target, episode ends (success)
+7. If any termination condition is met:
    - Final state is recorded
    - Reward is calculated
    - Episode concludes
-9. If no termination condition is met:
+8. If no termination condition is met:
    - Proceed to next round's Phase 1
 
-**Shutdown Note**: Shutdown is checked BEFORE bankruptcy. Shutdown represents governance failure (no agreement on budgets), not financial failure. Treasury may still be positive when Shutdown triggers.
+**Shutdown Note**: Shutdown is checked BEFORE bankruptcy. Shutdown represents governance stagnation (no approved discretionary growth for two consecutive rounds), not financial failure. Treasury may still be positive when Shutdown triggers.
 
 **Treasury Note**: Final treasury state is recorded at this point.
 
@@ -208,7 +209,7 @@ Treasury_after_Revenue = Treasury_before_Phase5 - sum(Allocation_d) + sum(Depart
 | 2. Debate/Discussion | No | No |
 | 3. Budget Proposal | No | No |
 | 4. Voting | No | No |
-| 5. Budget Execution | Yes (sum of approved allocations) | No |
+| 5. Budget Execution | Yes (`sum(Critical_d)` + approved discretionary) | No |
 | 6. Consumption & Event Impact | No | No |
 | 7. Revenue Calculation | No | Yes (same-round revenue credited immediately) |
 | 8. Treasury Surplus | No | Yes (unspent allocation returns) |
@@ -234,6 +235,6 @@ Equivalent formula: Treasury only pays for actual consumption minus revenue gene
 
 **Revenue from Productivity**: Revenue is multiplied by the persistent Productivity factor. Higher productivity means better revenue generation from the same allocation, creating an incentive for efficient spending.
 
-**Critical Threshold First**: The critical threshold check (40% of demand) occurs before any budget execution. This ensures departments receive minimum viable funding before the system attempts to generate revenue from them.
+**Auto-critical first**: Mandatory critical funding is applied before discretionary execution so every department has a survival floor when the treasury can afford it; revenue is then computed on the **total** allocation (critical + discretionary).
 
 **Productivity and Population Updates**: These persistent state variables are only updated in Phase 9, after all financial transactions for the round are complete. This ensures that productivity changes only affect the NEXT round's revenue calculation.

--- a/specification/04_ECONOMY_MODEL.md
+++ b/specification/04_ECONOMY_MODEL.md
@@ -1,6 +1,6 @@
 # 04 — Economy Model
 
-> Defines the complete economic engine: treasury calculation, revenue generation, productivity system, population dynamics, and critical failure conditions.
+> Defines the complete economic engine: treasury calculation, revenue generation, productivity system, population dynamics, and mandatory vs. discretionary budgeting (Option A).
 
 ---
 
@@ -40,7 +40,7 @@ Where:
 
 - `Critical_d = Demand_d × 0.4`
 
-This is the minimum viable allocation. Below this: **GAME OVER**.
+This is the **mandatory survival floor** funded automatically in Phase 5 (Step 0) before discretionary proposals execute. It is not a separate episode termination concept: if the treasury cannot pay `sum(Critical_d)`, the episode ends with **BANKRUPTCY**.
 
 ### Surplus Threshold
 
@@ -63,7 +63,7 @@ The revenue factor determines how efficiently allocation converts to revenue.
 ### Revenue Factor Formula
 
 ```
-         ⎧ None                           if x < Critical_d          (CRITICAL FAILURE)
+         ⎧ None                           if x < Critical_d          (invalid / no revenue)
          ⎪
 RF(x) =  ⎨ (x - Critical_d) / (Demand_d - Critical_d)   if Critical_d ≤ x < Demand_d
          ⎪
@@ -88,7 +88,7 @@ Revenue Factor (y)
     └──────┬────┬──────┬────→ Allocation (x)
          Critical Demand Surplus Wastage
 
-A (Critical): Revenue factor = 0, below = game over
+A (Critical): Revenue factor = 0 at exactly Critical; below Critical is undefined / no revenue (should not occur after auto-critical in normal play)
 B (Demand): Revenue factor = 1.0 (break-even)
 C (Surplus): Revenue factor = 1.8 (peak profit)
 D (Wastage): Revenue factor = 1.0 (break-even again)
@@ -105,8 +105,8 @@ D (Wastage): Revenue factor = 1.0 (break-even again)
 
 | Allocation (% of Demand) | Revenue Factor | Interpretation |
 |--------------------------|----------------|-----------------|
-| 0-39% | FAIL | Critical failure (game over) |
-| 40% | 0 | At critical threshold (break-even) |
+| 0-39% | None / 0 RF | Below critical: no revenue in model; **Option A** funds at least critical when solvent |
+| 40% | 0 | At critical threshold (zero revenue — survival cost only) |
 | 50% | 0.25 | Linear segment mid-point |
 | 100% | 1.0 | At demand (break-even) |
 | 150% | 1.8 | At surplus (peak profit) |
@@ -120,7 +120,7 @@ import math
 
 def revenue_factor(x, critical, demand, surplus, wastage):
     if x < critical:
-        return None  # CRITICAL FAILURE: episode terminates
+        return None  # No revenue for sub-critical allocation (hypothetical if execution guarantees critical)
     elif x < demand:
         # Segment A→B: Linear from (critical, 0) to (demand, 1.0)
         return (x - critical) / (demand - critical)
@@ -158,7 +158,7 @@ def calculate_department_revenue(allocation, baseline, population, pop_0, event_
     rf = revenue_factor(allocation, critical, demand, surplus, wastage)
     
     if rf is None:
-        return None  # CRITICAL FAILURE - episode terminates
+        return None  # No revenue (sub-critical allocation)
     
     # Calculate revenue (same round)
     revenue = allocation * rf * productivity
@@ -168,27 +168,33 @@ def calculate_department_revenue(allocation, baseline, population, pop_0, event_
 
 ---
 
-## Critical Threshold (Game-Over Condition)
+## Mandatory vs. discretionary budget (Option A)
 
-### Immediate Termination
+### Mandatory (auto-critical)
 
-If `Allocation_d < Critical_d` for **ANY** department, the episode terminates immediately with **CRITICAL FAILURE**.
+- Each round in Phase 5 Step 0, every department receives `Critical_d` before discretionary is applied
+- Debit: `sum(Critical_d)` from treasury
+- Revenue factor at `Allocation = Critical_d` is **0** → **zero department revenue** from that slice (pure cost to treasury)
 
-### Critical Failure Check
+### Discretionary (Phase 3 proposals)
 
-- Checked immediately after budget allocation (Phase 5)
-- Any single department below critical triggers failure
-- Final prosperity = `(Treasury + sum(Revenue)) / Population`
+- Ministers request **additional** amounts ≥ 0 above `Critical_d`
+- Voting approves or rejects **growth** funding; rejection implies `Discretionary_d = 0` but **not** `Allocation_d = 0`
+- Total allocation: `Allocation_d = Critical_d + Discretionary_d`
 
-### Critical Threshold Behavior
+### Affordability
 
-| Scenario | Allocation | Critical | Result |
-|----------|------------|----------|--------|
-| Severe underfunding | 30% of demand | 40% of demand | GAME OVER |
-| Moderate underfunding | 40% of demand | 40% of demand | Break-even at 0 |
-| Adequate funding | 50% of demand | 40% of demand | Survives |
-| Well funded | 100% of demand | 40% of demand | Thrives |
-| Over funded | 150% of demand | 40% of demand | Peak profit zone |
+- If treasury cannot cover `sum(Critical_d)` at the start of Phase 5 execution, the episode ends with **BANKRUPTCY**
+- There is **no** `CRITICAL_FAILURE` termination reason in Option A
+
+### Reference: RF vs allocation (given execution guarantees)
+
+| Scenario | Allocation | Critical | RF | Notes |
+|----------|------------|----------|-----|--------|
+| At auto-critical only | Critical | Critical | 0 | No revenue |
+| Between critical and demand | Between | Critical | 0–1 linear | Under-demand zone |
+| At demand | Demand | Critical | 1.0 | Break-even |
+| Profit zone | Demand–Surplus | Critical | 1.0–1.8 | Primary growth target |
 
 ---
 

--- a/specification/05_VOTING_PROTOCOL.md
+++ b/specification/05_VOTING_PROTOCOL.md
@@ -40,11 +40,9 @@
 
 ### Proposing (Phase 3)
 
-- A minister MAY abstain from proposing a budget for their department
-- Abstaining from proposing means the minister skips their turn in the proposal sequence
-- No treasury change occurs for abstained proposals
-- Abstaining minister does NOT propose anything this round
-- Abstention MUST be an explicit choice (agents must actively signal they are abstaining)
+- **Proposal abstention is removed under Option A.** Every minister MUST submit a `PROPOSE_BUDGET` action each round
+- The proposal’s `amount` is **discretionary** (≥ 0). Submitting **0** means “no extra above auto-critical” — it is not an abstention from the phase
+- Invalid proposals are rejected as invalid submissions; ministers must correct and resubmit until the phase completes
 
 ### Voting (Phase 4)
 
@@ -58,19 +56,19 @@
 
 ## Approval Consequences
 
-- **Approved**: Treasury is debited by the approved amount in Phase 5
-- **Approved**: Department receives the allocated budget
-- **Rejected**: No treasury change occurs
-- **Rejected**: Department receives zero allocation this round
+- **Approved (discretionary)**: In Phase 5 Step 1, treasury is debited by the **approved discretionary amount** for that department (in addition to the Step 0 auto-critical debit for all departments)
+- **Approved**: Department total allocation = `Critical_d + Discretionary_d`
+- **Rejected**: Department receives **only** auto-critical: `Allocation_d = Critical_d` (mandatory Step 0 still applies); **no** discretionary debit for that department’s rejected ask
+- Voting is therefore about **growth funding**, not survival
 
 ---
 
 ## Rejection Consequences
 
-- No treasury change for rejected proposals
-- Department receives zero allocation for that proposal round
-- Rejected proposals cannot be resubmitted in the same round
-- Department must wait until next round to request again
+- Auto-critical debits still apply to all departments when solvent
+- Rejected discretionary: department stays at **critical-only** funding; treasury is **not** debited for the rejected discretionary portion
+- Rejected proposals cannot be resubmitted in the same round (unless a retry / reopen flow is used by the environment wrapper)
+- Department may propose again next round
 
 ---
 
@@ -130,13 +128,12 @@
   - Later proposals exceeding remaining balance are auto-rejected
   - This creates strategic pressure around proposal ordering
 
-### All Ministers Abstain from Proposing
+### All ministers propose zero discretionary
 
-- Game proceeds to voting phase
-- No proposals to vote on
-- Round continues to Phase 5 and beyond
+- Every department still receives auto-critical in Phase 5
+- Shutdown counter may advance if `sum(Discretionary_d) = 0` for consecutive rounds (see Turn Structure)
 
-### Single Minister Remaining (all others abstained)
+### Single Minister Remaining (edge case)
 
 - If only one minister proposes and all others abstain from voting:
   - Their proposal requires YES votes from all non-abstaining (the single voter)
@@ -155,7 +152,7 @@
 | Proposal exceeds treasury | REJECTED (auto, before voting) |
 | Late submission | INVALID (ignored) |
 | Minister abstains from voting | Not counted toward majority |
-| Minister abstains from proposing | No proposal submitted |
+| Minister proposes 0 discretionary | Auto-critical only if approved path allows |
 
 ---
 

--- a/specification/07_AGENT_ACTION_SPACE.md
+++ b/specification/07_AGENT_ACTION_SPACE.md
@@ -8,34 +8,35 @@
 
 ### 1. PROPOSE_BUDGET
 
-Submit a budget allocation request for the agent's own department.
+Submit a **discretionary** budget request for the agent's own department: additional funding **above** the auto-funded critical floor `Critical_d`.
 
 **Parameters**:
 - `department` (string): Must match the agent's assigned portfolio
-- `amount` (number): Requested allocation, must be within valid range
+- `amount` (number): **Discretionary** amount ≥ 0 (extra above auto-critical; **0** = critical only)
 - `justification` (string): Narrative explaining the request
 
 **Constraints**:
 - `amount` must be >= 0
-- `amount` must be <= current treasury balance at submission time
+- `amount` must be <= **discretionary headroom** at submission time: `Treasury - sum(Critical_d)` (same validation as “remaining after mandatory critical”)
 - `amount` must be a numeric value (no strings, nulls, or NaN)
 - `department` must be the agent's own assigned department
 - One proposal per agent per round (first submission honored, subsequent ignored)
+- **Required every round** — there is no separate abstention action
 
 **Timing**: Phase 3 (Budget Proposal Phase) only
 
 **Valid Examples**:
-- `{department: "Health", amount: 300, justification: "Medical supplies"}`
-- `{department: "Defense", amount: 0, justification: "No needs this round"}`
+- `{department: "Health", amount: 20, justification: "Medical supplies above baseline"}`
+- `{department: "Defense", amount: 0, justification: "Critical only this quarter"}`
 
 **Invalid Examples**:
 - `{department: "Health", amount: -50, justification: "..."}` — negative amount
-- `{department: "Health", amount: 50000, justification: "..."}` — exceeds treasury
+- `{department: "Health", amount: 50000, justification: "..."}` — exceeds discretionary headroom
 - `{department: "Defense", amount: 100, justification: "..."}` — wrong department for agent
 
 **Outcome**:
 - Valid proposal: publicly announced, enters voting queue
-- Invalid proposal: rejected, agent must resubmit valid amount or abstain
+- Invalid proposal: rejected; agent must resubmit a valid proposal before the phase can complete
 
 ---
 
@@ -97,36 +98,13 @@ Send a public message visible to all agents during discussion phase.
 
 ---
 
-### 4. ABSTAIN_FROM_PROPOSAL
-
-Explicitly skip the agent's turn in the budget proposal phase.
-
-**Parameters**: None required (action is the absence of PROPOSE_BUDGET)
-
-**Constraints**:
-- Can only abstain during Phase 3 when it is the agent's turn
-- Abstention is explicit (agent must signal intent, not passive default)
-
-**Timing**: Phase 3 (Budget Proposal Phase) only
-
-**Effect**:
-- Agent submits no proposal for their department
-- Department receives zero allocation for this round
-- Treated as rejected proposal (no treasury change)
-
-**Invalid Examples**:
-- Abstaining outside Phase 3 — ignored
-- Abstaining when it is not the agent's turn — ignored
-
----
-
 ## Phase-Action Mapping
 
 | Phase | Available Actions |
 |-------|-------------------|
 | Phase 1: Event Revelation | None (observation only) |
 | Phase 2: Debate/Discussion | DEBATE |
-| Phase 3: Budget Proposal | PROPOSE_BUDGET, ABSTAIN_FROM_PROPOSAL |
+| Phase 3: Budget Proposal | PROPOSE_BUDGET |
 | Phase 4: Voting | VOTE |
 | Phase 5: Budget Execution | None (system executes) |
 | Phase 6: Consumption & Event Impact | None (system executes) |
@@ -145,7 +123,7 @@ Explicitly skip the agent's turn in the budget proposal phase.
 **Handling**: Proposal is REJECTED.
 
 - Agent receives error feedback indicating invalid amount
-- Agent may resubmit valid proposal or abstain
+- Agent must resubmit a valid proposal
 - No treasury change occurs
 
 **Examples**:
@@ -161,7 +139,7 @@ Explicitly skip the agent's turn in the budget proposal phase.
 
 **Handling**: Proposal is REJECTED.
 
-- Agent may resubmit with correct department or abstain
+- Agent may resubmit with correct department
 
 ---
 
@@ -209,7 +187,7 @@ Explicitly skip the agent's turn in the budget proposal phase.
 
 **Handling**: Proposal is REJECTED.
 
-- Agent may resubmit with valid numeric amount or abstain
+- Agent may resubmit with valid numeric amount
 
 ---
 
@@ -222,7 +200,7 @@ Agent State: IDLE
 Phase 2: Can perform DEBATE
   |
   v
-Phase 3: Can perform PROPOSE_BUDGET or ABSTAIN_FROM_PROPOSAL
+Phase 3: Can perform PROPOSE_BUDGET (required once per minister)
   |
   v
 Phase 4: Can perform VOTE on each proposal in queue
@@ -237,10 +215,9 @@ Phase 5+: No actions available (system-driven phases)
 
 | Action | Parameters | Phase | Constraint |
 |--------|------------|-------|------------|
-| PROPOSE_BUDGET | department, amount, justification | Phase 3 | 0 <= amount <= treasury |
+| PROPOSE_BUDGET | department, amount, justification | Phase 3 | 0 <= amount <= discretionary headroom |
 | VOTE | proposal_id, vote | Phase 4 | proposal must exist |
 | DEBATE | message | Phase 2 | none |
-| ABSTAIN_FROM_PROPOSAL | none | Phase 3 | must be agent's turn |
 
 ---
 
@@ -249,7 +226,7 @@ Phase 5+: No actions available (system-driven phases)
 ### Agent Submits Invalid Proposal Multiple Times
 
 - First invalid submission: rejected with error
-- Subsequent submissions: also rejected until valid or abstain
+- Subsequent submissions: also rejected until valid
 
 ### Agent Attempts Action During System Phase
 

--- a/specification/09_REWARD_MODEL.md
+++ b/specification/09_REWARD_MODEL.md
@@ -36,8 +36,10 @@ Where:
 ### Per-Step Reward
 
 ```
-R_t = Base_Reward_t + Productivity_Bonus_t + Survival_Bonus_t + Allocation_Penalty_t - Critical_Penalty_t
+R_t = Base_Reward_t + Productivity_Bonus_t + Survival_Bonus_t + Allocation_Penalty_t + Bankruptcy_Adjustment_t
 ```
+
+Under Option A there is **no** `-1000` “critical failure” penalty component: mandatory critical funding prevents that termination class. **Bankruptcy** may still apply a large negative adjustment via the same bookkeeping field in code (`critical_penalty` slot used for `BANKRUPTCY_PENALTY` in the reference implementation).
 
 ### Component Definitions
 
@@ -60,7 +62,7 @@ R_t = Base_Reward_t + Productivity_Bonus_t + Survival_Bonus_t + Allocation_Penal
 #### Survival Bonus
 
 - `Survival_Bonus_t = +10 × Rounds_Survived_t`
-- Encourages longevity and avoiding critical failure
+- Encourages longevity and sustained governance
 - Each round survived adds 10 to reward (accumulates over episode)
 - At round 10: survival bonus = 100
 - At round 50: survival bonus = 500
@@ -86,12 +88,10 @@ The piecewise curve creates three allocation zones with different penalty struct
 - This is the profit zone where revenue factor ranges from 1.0 to 1.8
 - Agents WANT to allocate in this zone, not exactly at demand
 
-#### Critical Penalty
+#### Bankruptcy adjustment (termination)
 
-- `Critical_Penalty_t = -1000` if `Allocation_d < Critical_d` for ANY sector
-- Large penalty triggers immediate episode termination
-- Final prosperity = `(Treasury + Total_Revenue) / Population` at termination
-- Rationale: Catastrophic failure requires strong disincentive; no recovery possible once below critical
+- When the episode ends in **BANKRUPTCY**, the reference implementation applies a large negative penalty (same magnitude historically used for hard failures) so terminal states remain clearly worse than healthy survival
+- There is **no** parallel penalty for “critical failure” as a termination reason — that condition was removed under Option A
 
 ---
 
@@ -107,12 +107,12 @@ The piecewise curve creates three allocation zones with different penalty struct
 
 - `Episode_Total = Sum(R_t for t = 1 to T)`
 - Sum of all per-step rewards across the episode
-- Maximized when episode reaches maximum rounds without critical failure
+- Maximized when episode reaches maximum rounds without bankruptcy / shutdown
 
-### Critical Failure Termination
+### Bankruptcy termination
 
-- If critical failure occurs at step t:
-  - Reward for step t includes -1000 critical penalty
+- If bankruptcy occurs at step t:
+  - Reward for step t includes the configured bankruptcy penalty (reference: -1000 via penalty slot)
   - Episode terminates immediately
   - Steps t+1 through T receive 0
 
@@ -168,7 +168,7 @@ Understanding allocation zones is essential for reward optimization:
 
 | Zone | Allocation Range | Revenue Factor | Reward Treatment |
 |------|-----------------|----------------|------------------|
-| **Critical Failure** | `x < Critical_d` | N/A | GAME OVER (-1000 penalty, episode ends) |
+| **At / above critical** | `x ≥ Critical_d` | 0 at critical, then 0–1.0 to demand | Under-demand band uses under-allocation penalty when `x < Demand_d` |
 | **Under-Funded** | `Critical_d ≤ x < Demand_d` | 0 to 1.0 (linear) | -10 per sector (under-allocation penalty) |
 | **Profit Zone** | `Demand_d ≤ x ≤ Surplus_d` | 1.0 to 1.8 (linear) | NO PENALTY (agents want to be here) |
 | **Wastage Zone** | `x > Surplus_d` | 1.8 decaying to 1.0+ | -5 per sector (over-allocation penalty) |
@@ -279,46 +279,15 @@ R_t = 0.000509 + 10 + 100 - 10 - 0 = 100.000509
 
 ---
 
-### Example 3: Critical Failure Round (Game Over)
+### Example 3: Bankruptcy Round (Game Over)
 
 **Setup:**
-- Treasury = 800
-- Population = 1,020,000
-- Productivity = 0.8 (sustained losses decreased productivity)
-- Round 15: Commerce allocation severely cut due to budget constraints
-- Commerce allocation below critical threshold
-
-**Critical Failure Scenario:**
-- Commerce: Baseline=75, Demand=75, Critical=30
-- Allocation = 25 (below critical of 30)
-
-**Revenue Check:**
-- Allocation (25) < Critical (30)
-- CRITICAL FAILURE: Episode terminates immediately
+- Treasury cannot cover `sum(Critical_d)` at Phase 5 execution (mandatory spend exceeds balance)
+- Episode terminates with **BANKRUPTCY**
 
 **Reward at Termination:**
-```
-Base_Reward = Prosperity_t (calculated before termination)
-Productivity_Bonus = +50 × (0.8 - 1.0) = -10 (low productivity)
-Survival_Bonus = +10 × 15 = +150 (15 rounds survived)
-Over_Allocation_Penalty = 0 (failure occurs before zone calculation)
-Under_Allocation_Penalty = 0 (failure occurs before zone calculation)
-Critical_Penalty = -1000 (sector below critical)
-
-R_t = Base_Reward + Productivity_Bonus + Survival_Bonus - 1000
-```
-
-Assume treasury and revenue before failure:
-- Treasury at termination = 800
-- Revenue generated = 0 (commerce failed before generating revenue)
-- Final prosperity = (800 + 0) / 1,020,000 = 0.000784
-- Base_Reward = 0.000784
-
-```
-R_15 = 0.000784 + (-10) + 150 - 1000 = -859.999216
-```
-
-**Result:** Large negative reward of approximately -860 due to critical penalty. Episode terminates; no further rewards accumulated.
+- Reference implementation: large negative bankruptcy adjustment on the terminal step (e.g. -1000 in the penalty slot), plus usual components where applicable
+- No separate “critical failure” component
 
 ---
 
@@ -331,7 +300,7 @@ R_15 = 0.000784 + (-10) + 150 - 1000 = -859.999216
 | Survival Bonus | `+10 × Rounds_Survived_t` | [0, +inf) |
 | Over-Allocation Penalty | `-5 × Count(sectors where Allocation > Surplus)` | (-inf, 0] |
 | Under-Allocation Penalty | `-10 × Count(sectors where Critical ≤ Allocation < Demand)` | (-inf, 0] |
-| Critical Penalty | `-1000 if any sector below Critical else 0` | {-1000, 0} |
+| Bankruptcy adjustment | Large negative on terminal bankruptcy step (implementation-defined) | (-inf, 0] |
 
 ---
 
@@ -355,11 +324,10 @@ R_15 = 0.000784 + (-10) + 150 - 1000 = -859.999216
 - High productivity amplifies all revenue generation, creating compounding rewards
 - This connects budget decisions to multi-round strategy, not just single-round optimization
 
-### Critical Threshold Severity
+### Mandatory critical and discretionary incentives
 
-- Below critical = immediate game over
-- Strong disincentive ensures agents maintain minimum viable funding across all sectors
-- Survival bonus accumulates faster than critical penalty recovery is possible
+- Auto-critical guarantees survival funding when solvent, so reward shaping focuses on **discretionary** investment and zone penalties (under / over demand vs. surplus)
+- Treasury stress appears as **bankruptcy** when mandatory spend is unaffordable
 
 ### Population Dynamics Impact
 
@@ -380,8 +348,8 @@ R_15 = 0.000784 + (-10) + 150 - 1000 = -859.999216
 | Efficiency Zone | `Allocation ≈ Need` (exact match) | `Demand ≤ Allocation ≤ Surplus` (profit zone) |
 | Over-Allocation | `-5 × Count(Allocation > Need)` | `-5 × Count(Allocation > Surplus)` (wastage zone only) |
 | Under-Allocation | `-10 × Count(Allocation < Need)` | `-10 × Count(Critical ≤ Allocation < Demand)` |
-| Failure Mode | Bankruptcy (treasury ≤ 0) | Critical Failure (any sector < Critical) |
-| Penalty Severity | -1000 for bankruptcy | -1000 for critical failure |
+| Failure Mode | Bankruptcy (treasury ≤ 0 or cannot pay `sum(Critical_d)` at execution) | (Critical failure termination removed under Option A) |
+| Penalty Severity | Large negative on terminal step (e.g. -1000) | — |
 
 **Key shift**: The new model rewards profit zone behavior rather than exact demand matching. Agents can target ~1.3× demand for peak revenue factor of 1.8 without penalty.
 

--- a/specification/10_SUCCESS_CRITERIA.md
+++ b/specification/10_SUCCESS_CRITERIA.md
@@ -6,47 +6,24 @@
 
 ## Episode Termination Conditions
 
-### Critical Failure (Immediate Termination)
-
-The episode ends immediately in failure when **ANY** department's allocation falls below its Critical Threshold.
-
-- **Critical Threshold**: 40% of Demand
-- **Trigger**: `Allocation_d < Critical_d` for any department
-- **Check Timing**: Immediately after budget allocation (Phase 5)
-- **Result**: Episode terminates with CRITICAL FAILURE status
-
-When critical failure occurs:
-- All agents receive a critical failure penalty of -1000 in that step's reward
-- All subsequent steps receive 0 reward
-- Final prosperity calculated as: `(Treasury + sum(Revenues)) / Population`
-
-**Critical Threshold Behavior**:
-| Allocation | Result |
-|------------|--------|
-| < 40% of Demand | CRITICAL FAILURE (game over) |
-| 40% of Demand | Break-even (revenue factor = 0) |
-| 100% of Demand | Break-even (revenue factor = 1.0) |
-| 150% of Demand | Peak profit (revenue factor = 1.8) |
-| > 250% of Demand | Diminishing returns (wastage zone) |
-
 ### Bankruptcy (Failure)
 
-The episode ends in failure when Treasury drops to 0 or below after same-round revenue calculation.
+The episode ends in failure when the treasury is insolvent relative to game rules.
 
-- **Check Timing**: End of Phase 5 (Budget Execution) after revenue applied
-- **Formula**: `Treasury_t = Treasury_{t-1} + Baseline_Tax + Sum(Revenues_t) - Sum(Allocations_d)`
-- **Bankruptcy**: `Treasury_t <= 0`
+- **Phase 5 (immediate path)**: If `Treasury < sum(Critical_d)` at the start of budget execution, the episode ends with **BANKRUPTCY** (cannot pay mandatory auto-critical)
+- **General path**: Treasury at or below zero after debits / standard checks (see Termination Check Phase)
+- **Check Timing**: Phase 5 for mandatory-funding bankruptcy; Phase 9 (and other guards) for zero-balance bankruptcy
 
 When bankruptcy occurs:
-- All agents receive a bankruptcy penalty of -1000 in that step's reward
+- All agents receive a bankruptcy penalty of -1000 in that step's reward (reference implementation)
 - All subsequent steps receive 0 reward
 - Episode total is capped below potential maximum
 
 ### Shutdown (Governance Collapse)
 
-The episode ends with status SHUTDOWN when total allocation equals zero for 2 consecutive rounds.
+The episode ends with status SHUTDOWN when **total approved discretionary** is zero for 2 consecutive rounds.
 
-- **Trigger**: `sum(Allocation_d) = 0` for 2 consecutive rounds
+- **Trigger**: `sum(Discretionary_d) = 0` for 2 consecutive rounds (Option A)
 - **Check Timing**: Phase 9 (Termination Check)
 
 When shutdown occurs:
@@ -101,7 +78,7 @@ When shutdown occurs:
 | **Strong** | Survives 40+ rounds with final prosperity > 2500 | 80% of marks |
 | **Competent** | Survives 30+ rounds with final prosperity > 1500 | 60% of marks |
 | **Developing** | Survives 20+ rounds with final prosperity > 800 | 40% of marks |
-| **Failed** | Critical failure before round 15 | No marks |
+| **Failed** | Bankruptcy or shutdown before round 15 | No marks |
 
 ---
 
@@ -120,11 +97,10 @@ When shutdown occurs:
 ### End State
 
 Episode concludes when any termination condition is met:
-1. **Critical Failure**: Any department allocated below Critical Threshold (40% of Demand)
-2. **Bankruptcy**: Treasury <= 0 after same-round revenue calculation
-3. **Shutdown**: Zero total allocation for 2 consecutive rounds
-4. **Max Rounds**: Episode reaches round 50 (12.5 years)
-5. **Prosperity Threshold**: Per-capita income meets threshold for 5 consecutive rounds
+1. **Bankruptcy**: Treasury cannot pay mandatory critical at Phase 5, or treasury <= 0 per termination checks
+2. **Shutdown**: Zero **total discretionary** for 2 consecutive rounds
+3. **Max Rounds**: Episode reaches round 50 (12.5 years)
+4. **Prosperity Threshold**: Per-capita income meets threshold for 5 consecutive rounds
 
 ### State Transitions
 
@@ -147,8 +123,8 @@ Termination Check (Phase 9)
 
 - **Behavior**: Random budget proposals across the full allocation range
 - **Expected Survival**: 5-10 rounds
-- **Characterization**: High probability of critical failure due to uncoordinated random allocations
-- **Why It Fails**: No learning; random proposals frequently allocate below critical threshold (< 40% of demand), triggering immediate episode termination
+- **Characterization**: High probability of bankruptcy or shutdown due to uncoordinated random discretionary requests
+- **Why It Fails**: No learning; random policy misallocates discretionary spend and bleeds treasury on auto-critical (RF=0 at critical) until bankruptcy or zero-discretionary shutdown
 
 ### Greedy Agent Baseline
 
@@ -175,8 +151,8 @@ Termination Check (Phase 9)
 
 | Allocation (% of Demand) | Revenue Factor | Zone |
 |--------------------------|----------------|------|
-| 0-39% | FAIL | Critical (game over) |
-| 40% | 0.0 | Critical (break-even) |
+| 0-39% | N/A | Sub-critical RF undefined; Option A funds at least critical when solvent |
+| 40% | 0.0 | At critical (zero revenue) |
 | 60% | 0.5 | Underfunded |
 | 80% | 0.75 | Underfunded |
 | 100% | 1.0 | Break-even (demand) |
@@ -229,7 +205,7 @@ For each trained agent evaluation, record:
 
 ## Design Rationale
 
-- **Critical failure as immediate termination**: Creates the highest stakes for budget allocation. A single department below 40% of demand ends the episode, forcing careful coordination across all departments.
+- **Mandatory critical with zero RF**: Auto-critical guarantees survival funding when solvent but generates no revenue, so episodes hinge on coordinated **discretionary** investment and treasury health (bankruptcy) rather than a separate “critical failure” termination.
 - **Prosperity threshold for success**: Provides a concrete winning condition that requires sustained performance, not just survival. Five consecutive rounds above threshold demonstrates stable governance.
 - **Four baseline comparisons**: Give clear benchmarks at different strategy complexity levels. The optimal baseline (~1.3× demand) demonstrates the profit zone insight.
 - **Revenue factor as key metric**: Since revenue factor directly determines treasury growth, tracking average revenue factor across episodes provides clear signal of agent performance.

--- a/tests/fixtures/reward_scenarios.py
+++ b/tests/fixtures/reward_scenarios.py
@@ -87,7 +87,7 @@ UNDERFUNDED_SURVIVABLE_REWARD = RewardScenario(
 )
 
 CRITICAL_FAILURE_REWARD = RewardScenario(
-    name="critical_failure_reward",
+    name="below_critical_zero_revenue_reward",
     economy=CRITICAL_FAILURE,
     population=INITIAL_POPULATION,
     productivity=INITIAL_PRODUCTIVITY,
@@ -98,8 +98,8 @@ CRITICAL_FAILURE_REWARD = RewardScenario(
         survival_bonus=10.0,
         over_allocation_penalty=0.0,
         under_allocation_penalty=0.0,
-        critical_penalty=-1000.0,
-        total=-990.0,
+        critical_penalty=0.0,
+        total=10.0,
     ),
 )
 

--- a/tests/integration/test_game_loop.py
+++ b/tests/integration/test_game_loop.py
@@ -17,7 +17,11 @@ DEPARTMENTS = ("Social", "Agriculture", "Health", "Education", "Defense", "Comme
 
 
 def make_game(seed: int = 7, **config_overrides) -> NationGame:
-    config = replace(GameConfig.from_json(), **config_overrides) if config_overrides else GameConfig.from_json()
+    config = (
+        replace(GameConfig.from_json(), **config_overrides)
+        if config_overrides
+        else GameConfig.from_json()
+    )
     game = NationGame(config=config, seed=seed)
     game.event_engine._distribution = {"no_event": 1.0}
     game.reset()
@@ -25,7 +29,11 @@ def make_game(seed: int = 7, **config_overrides) -> NationGame:
 
 
 def debate(agent_id: str = "Health") -> dict:
-    return {"type": ActionType.DEBATE, "agent_id": agent_id, "message": "Public priority signal"}
+    return {
+        "type": ActionType.DEBATE,
+        "agent_id": agent_id,
+        "message": "Public priority signal",
+    }
 
 
 def proposal(department: str, amount: float = 10.0) -> dict:
@@ -40,7 +48,12 @@ def proposal(department: str, amount: float = 10.0) -> dict:
 
 
 def vote(agent_id: str, proposal_id: str, choice: VoteChoice = VoteChoice.YES) -> dict:
-    return {"type": ActionType.VOTE, "agent_id": agent_id, "proposal_id": proposal_id, "vote": choice}
+    return {
+        "type": ActionType.VOTE,
+        "agent_id": agent_id,
+        "proposal_id": proposal_id,
+        "vote": choice,
+    }
 
 
 def every_eligible_vote(game: NationGame) -> list[dict]:
@@ -53,7 +66,9 @@ def every_eligible_vote(game: NationGame) -> list[dict]:
     ]
 
 
-def every_eligible_no_on_target_else_yes(game: NationGame, target_department: str) -> list[dict]:
+def every_eligible_no_on_target_else_yes(
+    game: NationGame, target_department: str
+) -> list[dict]:
     """NO on ``target_department``'s proposal; YES on all other proposals (from each eligible voter)."""
     return [
         vote(
@@ -153,7 +168,9 @@ def test_proposal_action_only_accepted_in_phase_3() -> None:
     accepted_result = game.step(proposal("Health"))
 
     assert wrong_phase_result.info["ignored_actions"][0]["reason"] == "wrong_phase"
-    assert accepted_result.info["accepted_actions"][0]["type"] == ActionType.PROPOSE_BUDGET
+    assert (
+        accepted_result.info["accepted_actions"][0]["type"] == ActionType.PROPOSE_BUDGET
+    )
 
 
 def test_vote_action_only_accepted_in_phase_4() -> None:
@@ -163,7 +180,9 @@ def test_vote_action_only_accepted_in_phase_4() -> None:
 
     game = make_game()
     submit_safe_proposals(game)
-    proposal_id = next(item.proposal_id for item in game.proposals if item.department != "Health")
+    proposal_id = next(
+        item.proposal_id for item in game.proposals if item.department != "Health"
+    )
 
     accepted_result = game.step(vote("Health", proposal_id))
 
@@ -174,7 +193,14 @@ def test_vote_action_only_accepted_in_phase_4() -> None:
 def test_wrong_phase_action_is_ignored() -> None:
     game = make_game()
 
-    result = game.step({"type": ActionType.VOTE, "agent_id": "Health", "proposal_id": "missing", "vote": VoteChoice.YES})
+    result = game.step(
+        {
+            "type": ActionType.VOTE,
+            "agent_id": "Health",
+            "proposal_id": "missing",
+            "vote": VoteChoice.YES,
+        }
+    )
 
     assert result.info["ignored_actions"][0]["reason"] == "wrong_phase"
     assert game.votes == []
@@ -195,7 +221,9 @@ def test_duplicate_proposal_is_ignored() -> None:
     game = make_game()
     advance_to_phase(game, Phase.PROPOSAL)
 
-    result = game.step([proposal("Health", amount=20.0), proposal("Health", amount=30.0)])
+    result = game.step(
+        [proposal("Health", amount=20.0), proposal("Health", amount=30.0)]
+    )
 
     assert len(game.proposals) == 1
     assert result.info["ignored_actions"][0]["reason"] == "duplicate_proposal"
@@ -216,7 +244,9 @@ def test_agents_cannot_propose_for_another_department() -> None:
 def test_self_vote_is_rejected() -> None:
     game = make_game()
     submit_safe_proposals(game)
-    health_proposal = next(item for item in game.proposals if item.department == "Health")
+    health_proposal = next(
+        item for item in game.proposals if item.department == "Health"
+    )
 
     result = game.step(vote("Health", health_proposal.proposal_id))
 
@@ -327,7 +357,10 @@ def test_dictator_direct_runs_economy_round_without_immediate_termination() -> N
 
 def test_revenue_succeeds_after_direct_allocation() -> None:
     game = make_game()
-    safe = {department: baseline * 1.3 for department, baseline in game.config.SECTOR_BASELINES.items()}
+    safe = {
+        department: baseline * 1.3
+        for department, baseline in game.config.SECTOR_BASELINES.items()
+    }
     first = game.step(safe)
     assert first.total_revenue > 0
 
@@ -353,6 +386,152 @@ def test_max_rounds_terminates_episode() -> None:
 
     assert game.done
     assert game.termination_reason == "MAX_ROUNDS"
+
+
+def test_auto_critical_is_funded_before_voted_proposals() -> None:
+    """Auto-critical is applied BEFORE approved discretionary proposals are added."""
+    game = make_game()
+    advance_to_phase(game, Phase.PROPOSAL)
+    game.step([proposal(department, amount=20.0) for department in DEPARTMENTS])
+    approve_all_pending_proposals(game)
+    game.step()  # Phase 5: Budget Execution
+
+    total_c = game._total_critical_funding()
+    # Every department gets critical funded automatically
+    for dept in DEPARTMENTS:
+        sector = game.sectors[dept]
+        assert sector.allocation >= float(sector.critical(game.population.value)), (
+            f"{dept} allocation {sector.allocation} < critical {sector.critical(game.population.value)}"
+        )
+
+    # Treasury was debited for total critical first
+    # Then debited for approved discretionary on top
+    approved_disc = sum(
+        p.amount for p in game.proposals if p.status == PROPOSAL_STATUS_APPROVED
+    )
+    expected_allocation = total_c + approved_disc
+    assert game.last_total_allocation == pytest.approx(expected_allocation)
+
+
+def test_discretionary_zero_proposal_is_valid() -> None:
+    """A proposal of amount=0 means 'I only need auto-critical, no extra'."""
+    game = make_game()
+    advance_to_phase(game, Phase.PROPOSAL)
+    # All departments propose 0 discretionary
+    game.step([proposal(department, amount=0.0) for department in DEPARTMENTS])
+    approve_all_pending_proposals(game)
+    game.step()  # Phase 5
+
+    # All proposals accepted (0 is valid)
+    assert all(p.status == PROPOSAL_STATUS_APPROVED for p in game.proposals)
+    # Every department still gets auto-critical
+    total_c = game._total_critical_funding()
+    assert game.last_total_allocation == pytest.approx(total_c)
+
+
+def test_rejected_proposal_allocates_critical_not_zero() -> None:
+    """Rejection means department gets ONLY auto-critical (not 0)."""
+    game = make_game()
+    advance_to_phase(game, Phase.PROPOSAL)
+    # Health proposes 90, everyone else 0
+    game.step(proposal("Health", amount=90.0))
+    game.step([proposal(d, amount=0.0) for d in DEPARTMENTS if d != "Health"])
+    # NO vote on Health's proposal
+    health_proposal = next(p for p in game.proposals if p.department == "Health")
+    game.step(every_eligible_no_on_target_else_yes(game, "Health"))
+
+    while game.phase != Phase.CONSUMPTION_AND_EVENT_IMPACT and not game.done:
+        if game.phase == Phase.DEBATE:
+            game.force_advance_phase()
+        else:
+            game.step()
+
+    assert health_proposal.status == PROPOSAL_STATUS_REJECTED
+    crit = float(game.sectors["Health"].critical(game.population.value))
+    # Health gets auto-critical (not 0) even though proposal was rejected
+    assert game.sectors["Health"].allocation == pytest.approx(crit)
+
+
+def test_shutdown_triggered_by_zero_discretionary_two_rounds() -> None:
+    """Shutdown = sum(Discretionary_d) = 0 for 2 consecutive rounds."""
+    game = make_game()
+    run_phase_loop_round(game)  # Round 1: all propose and approve
+
+    # Round 2: all propose 0 discretionary (all get auto-critical only)
+    advance_to_phase(game, Phase.PROPOSAL)
+    game.step([proposal(d, amount=0.0) for d in DEPARTMENTS])
+    approve_all_pending_proposals(game)
+    while game.phase != Phase.EVENT_REVELATION and not game.done:
+        if game.phase == Phase.DEBATE:
+            game.force_advance_phase()
+        else:
+            game.step()
+
+    assert game.shutdown_counter == 1
+    assert not game.done
+
+    # Round 3: again all propose 0
+    advance_to_phase(game, Phase.PROPOSAL)
+    game.step([proposal(d, amount=0.0) for d in DEPARTMENTS])
+    approve_all_pending_proposals(game)
+    while game.phase != Phase.EVENT_REVELATION and not game.done:
+        if game.phase == Phase.DEBATE:
+            game.force_advance_phase()
+        else:
+            game.step()
+
+    assert game.shutdown_counter == 2
+    assert game.done
+    assert game.termination_reason == "SHUTDOWN"
+
+
+def test_bankruptcy_when_treasury_less_than_total_critical() -> None:
+    """If treasury < sum(Critical_d) at budget execution, BANKRUPTCY triggers."""
+    game = make_game()
+    # Set treasury to be less than total critical
+    game.treasury.balance = 50.0  # Total critical is ~190
+    advance_to_phase(game, Phase.PROPOSAL)
+    game.step([proposal(d, amount=0.0) for d in DEPARTMENTS])
+    approve_all_pending_proposals(game)
+
+    result = game.step()
+
+    assert result.done
+    assert result.termination_reason == "BANKRUPTCY"
+
+
+def test_no_critical_failure_after_revenue_round() -> None:
+    """Auto-critical ensures critical failure is impossible. Treasury checks apply instead."""
+    game = make_game()
+    # Simulate under-funding scenario: treasury too low for all critical
+    game.treasury.balance = 100.0  # Below ~190 total critical
+    advance_to_phase(game, Phase.PROPOSAL)
+    game.step([proposal(d, amount=0.0) for d in DEPARTMENTS])
+    approve_all_pending_proposals(game)
+
+    result = game.step()
+
+    # Should be BANKRUPTCY (treasury < critical), NOT CRITICAL_FAILURE
+    assert result.done
+    assert result.termination_reason == "BANKRUPTCY"
+
+
+def test_direct_allocation_applies_auto_critical_first() -> None:
+    """Direct allocation shortcut auto-funds critical, then applies input as discretionary."""
+    game = make_game()
+    # Input mapping is legacy total desired allocation per department; engine splits
+    # into critical + discretionary after auto-funding critical.
+    safe = {
+        dept: baseline * 1.3 for dept, baseline in game.config.SECTOR_BASELINES.items()
+    }
+    result = game.step(safe)
+
+    assert not result.done
+    pop = int(result.observation["population"])
+    for dept in DEPARTMENTS:
+        alloc = result.observation["sectors"][dept]["allocation"]
+        crit = game.sectors[dept].critical(pop)
+        assert alloc >= float(crit)
 
 
 def test_seeded_reset_is_deterministic() -> None:

--- a/tests/unit/test_action_schema.py
+++ b/tests/unit/test_action_schema.py
@@ -50,3 +50,12 @@ def test_phase_action_mapping_matches_spec() -> None:
     assert valid_action_types_for_phase(Phase.PROPOSAL) == frozenset({"PROPOSE_BUDGET"})
     assert valid_action_types_for_phase(Phase.VOTING) == frozenset({"VOTE"})
     assert ActionType.DEBATE.value in valid_action_types_for_phase(Phase.DEBATE)
+
+
+def test_proposal_phase_allows_only_propose_budget() -> None:
+    assert valid_action_types_for_phase(Phase.PROPOSAL) == frozenset({"PROPOSE_BUDGET"})
+
+
+def test_proposal_phase_does_not_include_abstain() -> None:
+    abstains = valid_action_types_for_phase(Phase.PROPOSAL) & {"ABSTAIN_FROM_PROPOSAL"}
+    assert len(abstains) == 0

--- a/tests/unit/test_parliament.py
+++ b/tests/unit/test_parliament.py
@@ -2,7 +2,7 @@ import math
 
 import pytest
 
-from core.parliament import ParliamentRoundState, Proposal, ProposalAbstention, VoteRecord
+from core.parliament import ParliamentRoundState, Proposal, VoteRecord
 from schemas.actions import ActionType, VoteChoice
 from schemas.phases import Phase
 

--- a/tests/unit/test_reward.py
+++ b/tests/unit/test_reward.py
@@ -32,10 +32,10 @@ def test_under_and_over_penalties() -> None:
     assert reward.under_allocation_penalty == -30
 
 
-def test_critical_penalty() -> None:
-    reward = compute_reward(prosperity=0, critical_failure_occurred=True)
+def test_compute_reward_leaves_critical_penalty_zero() -> None:
+    reward = compute_reward(prosperity=0, rounds_survived=1)
 
-    assert reward.critical_penalty == -1000
+    assert reward.critical_penalty == 0.0
 
 
 def test_total_equals_component_sum() -> None:
@@ -45,7 +45,6 @@ def test_total_equals_component_sum() -> None:
         rounds_survived=3,
         over_allocated_count=1,
         under_allocated_count=2,
-        critical_failure_occurred=True,
     )
 
     assert reward.total == pytest.approx(

--- a/tests/unit/test_reward_fixtures.py
+++ b/tests/unit/test_reward_fixtures.py
@@ -21,7 +21,6 @@ def _compute_fixture_reward(scenario: RewardScenario) -> RewardBreakdown:
         rounds_survived=scenario.rounds_survived,
         over_allocated_count=economy.over_allocated_count,
         under_allocated_count=economy.under_allocated_count,
-        critical_failure_occurred=economy.critical_failure,
     )
 
 
@@ -60,8 +59,9 @@ def test_profit_zone_reward_has_no_allocation_penalties() -> None:
     assert reward.critical_penalty == 0.0
 
 
-def test_critical_failure_reward_applies_critical_penalty() -> None:
+def test_below_critical_fixture_has_no_critical_termination_penalty() -> None:
+    """Economy fixtures may mark RF=None below critical; reward has no -1000 term (Option A)."""
     reward = _compute_fixture_reward(CRITICAL_FAILURE_REWARD)
 
-    assert reward.critical_penalty == -1000.0
-    assert reward.total == pytest.approx(-990.0)
+    assert reward.critical_penalty == 0.0
+    assert reward.total == pytest.approx(10.0)


### PR DESCRIPTION
# Option A: Auto-Fund Critical + Discretionary Proposals

## Summary

This PR implements **Option A** from `specification/proposed-amendments/01-critical-threshold-abstention-voting-fix.md`.

**Mechanics:**

- **Phase 5 — Step 0 (auto-critical):** Every department receives `Critical_d = Demand_d × 0.4` before discretionary execution. `sum(Critical_d)` is debited unconditionally. If `Treasury < sum(Critical_d)`, the episode ends with **BANKRUPTCY** (not `CRITICAL_FAILURE`).
- **Phase 3:** Ministers propose **discretionary** amounts ≥ 0 (additional funding above auto-critical). `0` means “critical only.” **Proposal abstention is removed**; every minister must submit `PROPOSE_BUDGET`.
- **Phase 5 — Step 1:** Approved discretionary is added on top of auto-critical. **Rejection** leaves the department at **critical-only** (not zero allocation).
- **Revenue:** RF at exactly critical is **0** (zero revenue from that slice).
- **Shutdown:** Consecutive rounds with **`sum(Discretionary_d) = 0`** (two rounds), not zero total allocation.
- **Termination:** `CRITICAL_FAILURE` is removed. Remaining reasons: **BANKRUPTCY**, **SHUTDOWN**, **MAX_ROUNDS**, **PROSPERITY_THRESHOLD**.
- **Rewards:** No “critical failure” penalty in `compute_reward`. Bankruptcy still applies `BANKRUPTCY_PENALTY` via the `critical_penalty` field on the step breakdown (existing implementation pattern).

**Direct-allocation shortcut:** Still interprets the mapping as desired **total** per department; the engine applies auto-critical first, then discretionary from the remainder. **`StepResult.observation` now snapshots end-of-round state** before the next round’s `_start_round()` resets sector rows (fixes stale allocation in observations).

## Branch note

In this Cursor worktree, Git refused `feature/option-a-critical-auto-fund` because that branch is already checked out in another worktree. This commit is on **`feature/option-a-critical-auto-fund-8fmz`** (or the current HEAD branch at merge time). Rename or cherry-pick onto `feature/option-a-critical-auto-fund` as needed.

## Files changed

| Path | Change |
|------|--------|
| `core/game.py` | Remove `CRITICAL_FAILURE` / critical invariant path; simplify `_finish_round`; `compute_reward` call without critical penalty; direct allocation returns observation snapshot before next `_start_round`; `_result` accepts optional `observation`. |
| `core/reward.py` | Remove critical-failure penalty parameters and logic; document bankruptcy override on `RewardBreakdown.critical_penalty`. |
| `core/parliament.py` | Remove `ProposalAbstention`, `submit_abstention`, and `proposal_abstentions` from resolution state. |
| `core/__init__.py` | Drop `ProposalAbstention` export. |
| `server/models.py` | Remove `ABSTAIN_FROM_PROPOSAL` from `ParliamentaryAction.to_engine_dict`; doc discretionary proposals. |
| `scripts/deep_audit_run.py` | Root-cause printout for **BANKRUPTCY** instead of removed `CRITICAL_FAILURE`. |
| `specification/02_GAME_RULES_REFERENCE.md` | Must propose; auto-critical; discretionary; shutdown on zero discretionary; bankruptcy for unaffordable critical. |
| `specification/03_TURN_STRUCTURE.md` | Phase 5 Step 0/1; Phase 3 mandatory proposals; shutdown counter on discretionary; remove critical-failure phase text. |
| `specification/04_ECONOMY_MODEL.md` | Mandatory vs discretionary; RF=0 at critical; remove `CRITICAL_FAILURE` termination; align tables. |
| `specification/05_VOTING_PROTOCOL.md` | Rejection = critical-only; no proposal abstention. |
| `specification/07_AGENT_ACTION_SPACE.md` | Remove `ABSTAIN_FROM_PROPOSAL`; Phase 3 = `PROPOSE_BUDGET` only. |
| `specification/09_REWARD_MODEL.md` | Remove critical-failure penalty; bankruptcy adjustment; update examples/tables. |
| `specification/10_SUCCESS_CRITERIA.md` | Remove critical failure; shutdown discretionary; termination list. |
| `tests/fixtures/reward_scenarios.py` | Below-critical economy fixture: expect **no** -1000 reward penalty. |
| `tests/integration/test_game_loop.py` | Option A scenarios: auto-critical, zero discretionary, shutdown loop, bankruptcy, direct allocation observation, rejection = critical. |
| `tests/unit/test_action_schema.py` | Assert proposal phase excludes `ABSTAIN_FROM_PROPOSAL`. |
| `tests/unit/test_parliament.py` | Remove unused `ProposalAbstention` import. |
| `tests/unit/test_reward.py` | Remove critical-failure penalty test; assert default `critical_penalty` zero from `compute_reward`. |
| `tests/unit/test_reward_fixtures.py` | Align with reward changes; rename scenario assertion. |
| `PR_DESCRIPTION_OPTION_A.md` | This file. |

## Migration / API notes

- **`ABSTAIN_FROM_PROPOSAL` removed** from the OpenEnv `ParliamentaryAction` mapping. External agents and tools must use **`PROPOSE_BUDGET` with `amount: 0`** instead of abstaining.
- **`ProposalAbstention` removed** from `core.parliament` and package exports. Callers should only use `submit_proposal`.
- **Termination string `CRITICAL_FAILURE`** is no longer produced by `NationGame`. Metrics or dashboards keyed on it should use **BANKRUPTCY** / **SHUTDOWN** / etc.
- **`compute_reward`** no longer accepts `critical_failed` / `critical_failure_occurred` / `critical_penalty_val`.

## Test plan

- `uv sync --extra dev`
- `uv run pytest` (full suite; all tests green in this worktree)

## Intentionally not changed

- `core/revenue.py` (per amendment).
- `training/` (per user request; separate amendment).
